### PR TITLE
Add memory node summaries feature

### DIFF
--- a/src/graph/MemoryGraph.ts
+++ b/src/graph/MemoryGraph.ts
@@ -320,16 +320,25 @@ export class MemoryGraph {
     // Extract key entities if not provided
     const keyEntities = input.keyEntities || this.extractKeyEntities(input.content);
     
+    // Current timestamp for both content and summary (if provided)
+    const currentTimestamp = new Date().toISOString();
+    
     const node: MemoryNode = {
       id: this.generateId(),
       content: input.content,
-      timestamp: new Date().toISOString(),
+      timestamp: currentTimestamp,
       path: input.path || this.config.defaultPath || '/',
       tags: input.tags,
       domainRefs: input.domainRefs ? [...input.domainRefs] : undefined,
       title,
       keyEntities
     };
+    
+    // Add summary if provided
+    if (input.summary) {
+      node.content_summary = input.summary;
+      node.summary_timestamp = currentTimestamp;
+    }
 
     // Handle domain pointer if provided
     if (input.domainPointer) {
@@ -724,9 +733,23 @@ export class MemoryGraph {
       throw new Error(`Memory not found: ${input.id}`);
     }
 
+    const currentTimestamp = new Date().toISOString();
+
     // Update content if provided
     if (input.content !== undefined) {
       node.content = input.content;
+      node.timestamp = currentTimestamp;
+      
+      // If content is updated but summary is not provided, suggest reconsidering the summary
+      if (input.summary === undefined && node.content_summary) {
+        console.log(`Content updated for memory ${input.id}. Consider updating the summary as well.`);
+      }
+    }
+    
+    // Update summary if provided
+    if (input.summary !== undefined) {
+      node.content_summary = input.summary;
+      node.summary_timestamp = currentTimestamp;
     }
 
     // Update relationships if provided
@@ -743,7 +766,7 @@ export class MemoryGraph {
               target: rel.targetId,
               type,
               strength: rel.strength,
-              timestamp: new Date().toISOString(),
+              timestamp: currentTimestamp,
             });
           }
         });

--- a/src/graph/MermaidGenerator.ts
+++ b/src/graph/MermaidGenerator.ts
@@ -321,6 +321,11 @@ export class MermaidGenerator {
     // Always truncate for Mermaid graphs to keep them readable
     parts.push(this.truncateContent(content, format?.maxLength, format?.truncationSuffix));
     
+    // Add summary if available
+    if (node.content_summary) {
+      parts.push(`\nSummary: ${this.truncateContent(node.content_summary, format?.maxLength, format?.truncationSuffix)}`);
+    }
+    
     if (format?.includeTimestamp) {
       // Parse the UTC timestamp
       const utcDate = new Date(node.timestamp);
@@ -348,6 +353,18 @@ export class MermaidGenerator {
       const dateStr = dateFormatter.format(cstDate);
       const timeStr = timeFormatter.format(cstDate);
       parts.push(`(${dateStr} ${timeStr})`);
+      
+      // Add summary timestamp if available and different from content timestamp
+      if (node.content_summary && node.summary_timestamp && node.summary_timestamp !== node.timestamp) {
+        const summaryUtcDate = new Date(node.summary_timestamp);
+        const summaryCstDate = new Date(summaryUtcDate);
+        summaryCstDate.setUTCHours(summaryUtcDate.getUTCHours() - 6);
+        summaryCstDate.setHours(12, 0, 0);
+        
+        const summaryDateStr = dateFormatter.format(summaryCstDate);
+        const summaryTimeStr = timeFormatter.format(summaryCstDate);
+        parts.push(`(Summary: ${summaryDateStr} ${summaryTimeStr})`);
+      }
     }
 
     return parts.join(' ');

--- a/src/tools/memoryTools.ts
+++ b/src/tools/memoryTools.ts
@@ -126,7 +126,9 @@ export const MEMORY_TOOLS = {
     description: `Store a new memory in the knowledge graph.
 During dreaming: Create at most 1-2 new synthesized memories per dreaming session.
 Focus only on clear, significant patterns that emerge across multiple memories.
-Avoid creating abstract memories that don't add concrete value.`,
+Avoid creating abstract memories that don't add concrete value.
+
+The summary should be a short sentence that captures the essence of the memory content.`,
     inputSchema: {
       type: 'object',
       properties: {
@@ -142,6 +144,10 @@ Avoid creating abstract memories that don't add concrete value.`,
           type: 'array',
           items: { type: 'string' },
           description: 'Optional categorization tags',
+        },
+        summary: {
+          type: 'string',
+          description: 'Optional short summary of the content (should be a single sentence)',
         },
         relationships: {
           type: 'object',
@@ -264,7 +270,10 @@ in the connections. Stay focused on the core topic being dreamed about.`,
     description: `Edit an existing memory in the knowledge graph.
 During dreaming: Limit edits to 2-3 memories per session. Focus on obvious
 consolidation opportunities where memories are clearly redundant. Don't over-edit
-or try to force connections - memories can retain their unique perspectives.`,
+or try to force connections - memories can retain their unique perspectives.
+
+When editing a memory's content, you should also reconsider its summary to ensure it still accurately
+represents the updated content. The summary should be a short sentence that captures the essence of the memory.`,
     inputSchema: {
       type: 'object',
       properties: {
@@ -275,6 +284,10 @@ or try to force connections - memories can retain their unique perspectives.`,
         content: {
           type: 'string',
           description: 'New content for the memory',
+        },
+        summary: {
+          type: 'string',
+          description: 'New summary for the memory (should be a single sentence)',
         },
         relationships: {
           type: 'object',
@@ -480,8 +493,19 @@ export class MemoryTools {
           output += `## Memory ${i+1}: ${node.id}\n\n`;
           output += `${node.content}\n\n`;
           
+          // Add summary if available
+          if (node.content_summary) {
+            output += `**Summary:** ${node.content_summary}\n\n`;
+          }
+          
           // Add metadata
           output += `*Created: ${new Date(node.timestamp).toLocaleString()}*\n`;
+          
+          // Add summary timestamp if available and different from content timestamp
+          if (node.content_summary && node.summary_timestamp && node.summary_timestamp !== node.timestamp) {
+            output += `*Summary updated: ${new Date(node.summary_timestamp).toLocaleString()}*\n`;
+          }
+          
           if (node.path) {
             output += `*Path: ${node.path}*\n`;
           }
@@ -580,13 +604,35 @@ export class MemoryTools {
           } else if (resolutionDepth === 'standard') {
             // Show title and content
             output += `${node.content}\n\n`;
+            
+            // Add summary if available
+            if (node.content_summary) {
+              output += `**Summary:** ${node.content_summary}\n\n`;
+            }
+            
             output += `*Created: ${new Date(node.timestamp).toLocaleString()}*\n`;
+            
+            // Add summary timestamp if available and different from content timestamp
+            if (node.content_summary && node.summary_timestamp && node.summary_timestamp !== node.timestamp) {
+              output += `*Summary updated: ${new Date(node.summary_timestamp).toLocaleString()}*\n`;
+            }
           } else {
             // Detailed or comprehensive - show everything
             output += `${node.content}\n\n`;
             
+            // Add summary if available
+            if (node.content_summary) {
+              output += `**Summary:** ${node.content_summary}\n\n`;
+            }
+            
             // Add metadata
             output += `*Created: ${new Date(node.timestamp).toLocaleString()}*\n`;
+            
+            // Add summary timestamp if available and different from content timestamp
+            if (node.content_summary && node.summary_timestamp && node.summary_timestamp !== node.timestamp) {
+              output += `*Summary updated: ${new Date(node.summary_timestamp).toLocaleString()}*\n`;
+            }
+            
             if (node.path) {
               output += `*Path: ${node.path}*\n`;
             }

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -35,6 +35,8 @@ export interface MemoryNode {
   domainRefs?: DomainRef[];
   title?: string;           // Short descriptive title
   keyEntities?: string[];   // Extracted key entities/concepts
+  content_summary?: string; // Short summary of the content
+  summary_timestamp?: string; // When the summary was last updated
 }
 
 export interface GraphEdge {
@@ -68,6 +70,7 @@ export interface StoreMemoryInput {
   domainPointer?: DomainPointer;
   title?: string;           // Optional title for the memory
   keyEntities?: string[];   // Optional key entities/concepts
+  summary?: string;         // Optional summary of the content
 }
 
 export type RecallStrategy = 'recent' | 'related' | 'path' | 'tag' | 'content';
@@ -106,6 +109,7 @@ export interface EditMemoryInput {
   relationships?: {
     [type: string]: Relationship[];
   };
+  summary?: string;  // Optional summary of the content
 }
 
 export interface ForgetMemoryInput {


### PR DESCRIPTION
This commit adds support for memory node summaries:
- Add content_summary and summary_timestamp fields to MemoryNode interface
- Update StoreMemoryInput and EditMemoryInput interfaces to include summary field
- Modify MemoryGraph to handle summaries in store and edit operations
- Update MermaidGenerator to display summaries in node presentations
- Enhance memory tools to include summaries in input schemas and output
- Update storage implementations to handle the new fields