### PR TITLE
Add ability to edit and move memories between domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ To use the Docker container with Claude, update your MCP configuration:
         "run",
         "--rm",
         "-i",
+        "--user", "1000:1000",
         "-v", "/path/to/data:/app/data",
         "-e", "MEMORY_DIR=/app/data",
         "-e", "STORAGE_TYPE=sqlite",
@@ -76,6 +77,8 @@ To use the Docker container with Claude, update your MCP configuration:
   }
 }
 ```
+
+**Important**: Replace `1000:1000` with your actual user and group IDs. You can find these by running `id -u` and `id -g` in your terminal.
 
 ### Local Usage
 

--- a/docs/memoryArchitecture.md
+++ b/docs/memoryArchitecture.md
@@ -116,6 +116,24 @@ sequenceDiagram
     M->>C: Return node
 ```
 
+### Memory Domain Transfer
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant M as MemoryGraph
+    participant FS as FileSystem
+
+    C->>M: editMemory({id, targetDomain})
+    M->>M: Validate targetDomain exists
+    M->>M: Remove node from source domain
+    M->>M: Save source domain state
+    M->>M: Switch to target domain
+    M->>M: Add node to target domain
+    M->>M: Save target domain state
+    M->>M: Switch back to original domain
+    M->>C: Return updated node
+```
+
 ## Usage Examples
 
 ### Creating a Domain
@@ -143,6 +161,23 @@ await graph.storeMemory({
     nodeId: workMemory.id,
     description: 'Related work project'
   }]
+});
+```
+
+### Moving Memory Between Domains
+```typescript
+// Move a memory from the current domain to the 'archives' domain
+await graph.editMemory({
+  id: 'memory123',
+  targetDomain: 'archives'
+});
+
+// Edit content and move to another domain in one operation
+await graph.editMemory({
+  id: 'memory456',
+  content: 'Updated content with new information',
+  summary: 'Updated project notes',
+  targetDomain: 'projects'
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.9.0",
+        "@modelcontextprotocol/sdk": "^1.11.0",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
         "typescript": "^5.0.0"
@@ -926,9 +926,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.9.0.tgz",
-      "integrity": "sha512-Jq2EUCQpe0iyO5FGpzVYDNFR6oR53AIrwph9yWl7uSc7IWUMsrmpmSaTGra5hQNunXpM+9oit85p924jWuHzUA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.0.tgz",
+      "integrity": "sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@modelcontextprotocol/sdk": "^1.11.0",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
     "typescript": "^5.0.0"

--- a/src/tools/memoryTools.ts
+++ b/src/tools/memoryTools.ts
@@ -273,7 +273,9 @@ consolidation opportunities where memories are clearly redundant. Don't over-edi
 or try to force connections - memories can retain their unique perspectives.
 
 When editing a memory's content, you should also reconsider its summary to ensure it still accurately
-represents the updated content. The summary should be a short sentence that captures the essence of the memory.`,
+represents the updated content. The summary should be a short sentence that captures the essence of the memory.
+
+You can move a memory to a different domain by specifying the targetDomain parameter.`,
     inputSchema: {
       type: 'object',
       properties: {
@@ -312,6 +314,10 @@ represents the updated content. The summary should be a short sentence that capt
             },
           },
         },
+        targetDomain: {
+          type: 'string',
+          description: 'Target domain to move the memory to',
+        }
       },
       required: ['id'],
     },

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -110,6 +110,7 @@ export interface EditMemoryInput {
     [type: string]: Relationship[];
   };
   summary?: string;  // Optional summary of the content
+  targetDomain?: string; // Target domain to move the memory to
 }
 
 export interface ForgetMemoryInput {


### PR DESCRIPTION
## Summary
- Add ability to move memories between domains using the `edit_memory` tool
- Update documentation to properly handle file permissions in Docker configurations
- Update to latest MCP SDK (v1.11.0) for improved domain validation support

## Test plan
1. Run the memory-graph MCP server
2. Create two domains using `create_domain`
3. Create a memory in one domain
4. Use `edit_memory` with `targetDomain` parameter to move the memory to the second domain
5. Verify the memory appears in the second domain and is removed from the first

This functionality allows for better organization of memories as contexts evolve, without needing to delete and recreate memories.