### PR TITLE
Add HTTP transport support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,10 @@ WORKDIR /app
 
 # Copy package files and install dependencies
 COPY package*.json ./
-RUN npm ci
+RUN apt-get update && apt-get install -y wget && \
+    npm ci && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy built files from builder stage
 COPY --from=builder /app/build ./build
@@ -33,6 +36,19 @@ RUN chmod +x build/index.js
 
 # Create data directory with permissions that allow any user to write to it
 RUN mkdir -p /app/data && chmod 777 /app/data
+
+# Environment variables
+ENV TRANSPORT_TYPE=STDIO
+ENV HOST=127.0.0.1
+
+# Add healthcheck for HTTP transport
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD if [ "$TRANSPORT_TYPE" = "HTTP" ]; then \
+        if [ -z "$PORT" ]; then exit 1; fi; \
+        wget --no-verbose --tries=1 --spider http://${HOST:-127.0.0.1}:$PORT/mcp || exit 1; \
+    else \
+        exit 0; \
+    fi
 
 # Set the entrypoint
 ENTRYPOINT ["node", "build/index.js"]

--- a/README.md
+++ b/README.md
@@ -40,10 +40,23 @@ Replace `[owner]` with your GitHub username or organization.
 
 ### Docker Usage
 
-Run the container with your desired configuration:
+Run the container with your desired configuration. The server supports two transport types:
 
 ```bash
-docker run -v /path/to/data:/app/data -e MEMORY_DIR=/app/data ghcr.io/[owner]/memory-graph:latest
+# Using STDIO transport (default)
+docker run -v /path/to/data:/app/data \
+  -e MEMORY_DIR=/app/data \
+  -e TRANSPORT_TYPE=STDIO \
+  ghcr.io/[owner]/memory-graph:latest
+
+# Using HTTP transport
+docker run -v /path/to/data:/app/data \
+  -e MEMORY_DIR=/app/data \
+  -e TRANSPORT_TYPE=HTTP \
+  -e PORT=3000 \
+  -e HOST=127.0.0.1 \
+  -p 3000:3000 \
+  ghcr.io/[owner]/memory-graph:latest
 ```
 
 Environment variables and volume mounts:
@@ -69,6 +82,9 @@ To use the Docker container with Claude, update your MCP configuration:
         "-e", "MEMORY_DIR=/app/data",
         "-e", "STORAGE_TYPE=sqlite",
         "-e", "STRICT_MODE=true",
+        "-e", "TRANSPORT_TYPE=HTTP",
+        "-e", "PORT=3000",
+        "-p", "3000:3000",
         "ghcr.io/[owner]/memory-graph:latest"
       ],
       "disabled": false,
@@ -100,6 +116,9 @@ The server can be configured using environment variables:
 - `DEFAULT_PATH`: Default path for storing memories
 - `STORAGE_TYPE`: Storage backend to use (`json` or `sqlite`, default: `json`)
 - `STRICT_MODE`: Set to 'true' to ensure all logging goes to stderr, preventing interference with JSON-RPC communication on stdout. See [Strict Mode](docs/strict-mode.md) for details.
+- `TRANSPORT_TYPE`: Communication transport to use (`STDIO` or `HTTP`, default: `STDIO`)
+- `PORT`: Port number for HTTP transport (required when `TRANSPORT_TYPE=HTTP`)
+- `HOST`: Host address for HTTP transport (default: `127.0.0.1`, only used when `TRANSPORT_TYPE=HTTP`)
 
 ### Storage Options
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  memory-graph:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: memory-graph:local
+    volumes:
+      - /home/aaron/Documents/memory-graph-mcp:/app/data
+    environment:
+      - MEMORY_DIR=/app/data
+      - STORAGE_TYPE=sqlite
+      - TRANSPORT_TYPE=HTTP
+      - PORT=3000
+      - HOST=127.0.0.1  # Internal network binding only
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/mcp"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.0",
+        "express": "^5.1.0",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
         "typescript": "^5.0.0"
       },
       "devDependencies": {
+        "@types/express": "^5.0.1",
         "@types/jest": "^29.0.0",
         "@types/node": "^22.14.1",
         "jest": "^29.0.0",
@@ -1095,6 +1097,52 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.1.tgz",
+      "integrity": "sha512-UZUw8vjpWFXuDnjFTh7/5c2TWDlQqeXHi6hcN7F2XSVT5P+WmUnnbFS3KA6Jnc6IsEqI2qCVu2bK0R0J4A8ZQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1104,6 +1152,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -1143,6 +1198,13 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.14.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
@@ -1151,6 +1213,43 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.18",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
   "license": "ISC",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
+    "express": "^5.1.0",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
     "typescript": "^5.0.0"
   },
   "devDependencies": {
+    "@types/express": "^5.0.1",
     "@types/jest": "^29.0.0",
     "@types/node": "^22.14.1",
     "jest": "^29.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from './transport/StreamableHTTPServerTransport.js';
+import express from 'express';
+import { randomUUID } from 'crypto';
 import {
   CallToolRequestSchema,
   ErrorCode,
@@ -23,6 +26,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 interface MemoryGraphServerConfig {
   strictMode?: boolean;
+  transportType?: 'STDIO' | 'HTTP';
+  port?: number;
+  host?: string;
 }
 
 class MemoryGraphServer {
@@ -190,16 +196,74 @@ class MemoryGraphServer {
     });
   }
 
+  private async startHttpTransport() {
+    if (!this.config.port) {
+      throw new Error('PORT environment variable is required for HTTP transport');
+    }
+
+    const port = this.config.port;
+    const host = this.config.host || '127.0.0.1';
+    const app = express();
+    app.use(express.json());
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      eventStore: new Map(),
+    });
+
+    app.all('/mcp', async (req, res) => {
+      try {
+        await transport.handleRequest(req, res, req.body);
+      } catch (error) {
+        console.error('Error handling MCP request:', error);
+        if (!res.headersSent) {
+          res.status(500).json({
+            jsonrpc: '2.0',
+            error: { code: -32603, message: 'Internal server error' },
+            id: null,
+          });
+        }
+      }
+    });
+
+    await this.server.connect(transport);
+
+    const server = app.listen(port, host, () => {
+      console.error(`Memory Graph MCP server running on http://${host}:${port}/mcp`);
+    });
+
+    server.on('error', (error: any) => {
+      if (error.code === 'EADDRINUSE') {
+        console.error(`Port ${port} is already in use`);
+      } else {
+        console.error('HTTP server error:', error);
+      }
+      process.exit(1);
+    });
+  }
+
+  private async startStdioTransport() {
+    const transport = new StdioServerTransport();
+    await this.server.connect(transport);
+    console.error('Memory Graph MCP server running on stdio');
+  }
+
   async start() {
     try {
       // Initialize memory graph
       await this.memoryGraph.initialize();
 
-      // Connect to transport
-      const transport = new StdioServerTransport();
-      await this.server.connect(transport);
-
-      console.error('Memory Graph MCP server running on stdio');
+      // Initialize transport based on configuration
+      const transportType = this.config.transportType || 'STDIO';
+      
+      // Explicitly separate transport initialization
+      if (transportType === 'HTTP') {
+        await this.startHttpTransport();
+      } else if (transportType === 'STDIO') {
+        await this.startStdioTransport();
+      } else {
+        throw new Error(`Invalid transport type: ${transportType}`);
+      }
     } catch (error) {
       console.error('Failed to start server:', error);
       process.exit(1);
@@ -209,7 +273,22 @@ class MemoryGraphServer {
 
 // Start server
 const strictMode = process.env.STRICT_MODE === 'true';
-const server = new MemoryGraphServer({ strictMode });
+const transportType = (process.env.TRANSPORT_TYPE || 'STDIO').toUpperCase();
+const port = process.env.PORT ? parseInt(process.env.PORT) : undefined;
+const host = process.env.HOST || '127.0.0.1';
+
+// Validate transport type
+if (transportType !== 'STDIO' && transportType !== 'HTTP') {
+  console.error(`Invalid TRANSPORT_TYPE: ${transportType}. Must be either 'STDIO' or 'HTTP'`);
+  process.exit(1);
+}
+
+const server = new MemoryGraphServer({ 
+  strictMode,
+  transportType: transportType as 'STDIO' | 'HTTP',
+  port,
+  host
+});
 server.start().catch((error) => {
   console.error('Failed to start server:', error);
   process.exit(1);

--- a/src/transport/StreamableHTTPServerTransport.ts
+++ b/src/transport/StreamableHTTPServerTransport.ts
@@ -1,0 +1,141 @@
+import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { Request, Response } from 'express';
+
+interface StreamableHTTPServerTransportOptions {
+  sessionIdGenerator: () => string;
+  eventStore: Map<string, JSONRPCMessage[]>;
+}
+
+export class StreamableHTTPServerTransport implements Transport {
+  private sessions: Map<string, Response>;
+  private eventStore: Map<string, JSONRPCMessage[]>;
+  private sessionIdGenerator: () => string;
+  private currentSessionId: string | null;
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+
+  constructor(options: StreamableHTTPServerTransportOptions) {
+    this.sessionIdGenerator = options.sessionIdGenerator;
+    this.eventStore = options.eventStore;
+    this.sessions = new Map();
+    this.currentSessionId = null;
+  }
+
+  get sessionId(): string | undefined {
+    return this.currentSessionId || undefined;
+  }
+
+  async start(): Promise<void> {
+    // No-op for HTTP transport
+  }
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    if (!this.currentSessionId) {
+      throw new Error('No active session');
+    }
+
+    const res = this.sessions.get(this.currentSessionId);
+    if (!res) {
+      // Store message for later retrieval if session not active
+      const events = this.eventStore.get(this.currentSessionId) || [];
+      events.push(message);
+      this.eventStore.set(this.currentSessionId, events);
+      return;
+    }
+
+    // Send message immediately if session is active
+    const event = `data: ${JSON.stringify(message)}\n\n`;
+    res.write(event);
+  }
+
+  async handleRequest(req: Request, res: Response, body: JSONRPCMessage): Promise<void> {
+    // Add CORS headers
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-MCP-Session-ID');
+    res.setHeader('Access-Control-Expose-Headers', 'X-MCP-Session-ID');
+
+    // Handle preflight requests
+    if (req.method === 'OPTIONS') {
+      res.status(200).end();
+      return;
+    }
+
+    // Generate or use existing session ID
+    const sessionId = (req.headers['x-mcp-session-id'] as string) || this.sessionIdGenerator();
+    this.currentSessionId = sessionId;
+
+    // Ensure session ID is set in response headers
+    res.setHeader('X-MCP-Session-ID', sessionId);
+
+    // Handle session establishment
+    if (req.method === 'GET') {
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Connection', 'keep-alive');
+
+      // Send any stored events
+      const storedEvents = this.eventStore.get(sessionId) || [];
+      for (const event of storedEvents) {
+        const eventData = `data: ${JSON.stringify(event)}\n\n`;
+        res.write(eventData);
+      }
+      this.eventStore.delete(sessionId);
+
+      // Store response object for sending future events
+      this.sessions.set(sessionId, res);
+
+      // Clean up when client disconnects
+      req.on('close', () => {
+        if (this.currentSessionId === sessionId) {
+          this.currentSessionId = null;
+        }
+        this.sessions.delete(sessionId);
+        if (this.onclose) {
+          this.onclose();
+        }
+      });
+
+      return;
+    }
+
+    // Handle incoming messages
+    if (req.method === 'POST') {
+      // Handle received message
+      if (this.onmessage) {
+        this.onmessage(body);
+      }
+
+      res.json({ ok: true });
+      return;
+    }
+
+    const error = new Error(`Method ${req.method} not allowed. Supported methods: GET, POST, OPTIONS`);
+    if (this.onerror) {
+      this.onerror(error);
+    }
+    res.status(405).json({
+      jsonrpc: '2.0',
+      error: {
+        code: -32601,
+        message: error.message
+      },
+      id: null
+    });
+  }
+
+  async close(): Promise<void> {
+    // Close all active sessions
+    for (const [sessionId, res] of this.sessions) {
+      res.end();
+      this.sessions.delete(sessionId);
+    }
+    this.eventStore.clear();
+    this.currentSessionId = null;
+    if (this.onclose) {
+      this.onclose();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add HTTP transport capability alongside STDIO
- Add Docker configuration with health checks for HTTP mode
- Support environment variables for configuring transport type
- Allow switching between STDIO and HTTP transports

## Test plan
- Run the server with HTTP transport and verify connectivity
- Test Docker deployment with HTTP transport