### PR TITLE
Add MariaDB storage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,36 @@ To use the Docker container with Claude, update your MCP configuration:
 }
 ```
 
+For MariaDB with Docker:
+
+```json
+{
+  "mcpServers": {
+    "memory-graph": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "--network=host",
+        "-v", "/path/to/data:/app/data",
+        "-e", "MEMORY_DIR=/app/data",
+        "-e", "STORAGE_TYPE=mariadb",
+        "-e", "MARIADB_HOST=localhost",
+        "-e", "MARIADB_PORT=3306",
+        "-e", "MARIADB_USER=memory_user",
+        "-e", "MARIADB_PASSWORD=secure_password",
+        "-e", "MARIADB_DATABASE=memory_graph",
+        "-e", "STRICT_MODE=true",
+        "ghcr.io/[owner]/memory-graph:latest"
+      ],
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
 **Important**: Replace `1000:1000` with your actual user and group IDs. You can find these by running `id -u` and `id -g` in your terminal.
 
 ### Local Usage
@@ -98,12 +128,21 @@ The server can be configured using environment variables:
 - `MEMORY_FILES`: Comma-separated list of specific memory files to use
 - `LOAD_ALL_FILES`: Set to 'true' to load all JSON files in the storage directory
 - `DEFAULT_PATH`: Default path for storing memories
-- `STORAGE_TYPE`: Storage backend to use (`json` or `sqlite`, default: `json`)
+- `STORAGE_TYPE`: Storage backend to use (`json`, `sqlite`, or `mariadb`, default: `json`)
 - `STRICT_MODE`: Set to 'true' to ensure all logging goes to stderr, preventing interference with JSON-RPC communication on stdout. See [Strict Mode](docs/strict-mode.md) for details.
+
+#### MariaDB Configuration (when using `STORAGE_TYPE=mariadb`)
+
+- `MARIADB_HOST`: Database server hostname (default: `localhost`)
+- `MARIADB_PORT`: Database server port (default: `3306`)
+- `MARIADB_USER`: Database username (default: `root`)
+- `MARIADB_PASSWORD`: Database password (default: empty)
+- `MARIADB_DATABASE`: Database name (default: `memory_graph`)
+- `MARIADB_CONNECTION_LIMIT`: Maximum number of connections in the pool (default: `10`)
 
 ### Storage Options
 
-The Memory Graph MCP supports two storage backends:
+The Memory Graph MCP supports three storage backends:
 
 - **JSON**: Simple file-based storage (default)
   - One JSON file per domain in the `memories/` directory
@@ -115,8 +154,16 @@ The Memory Graph MCP supports two storage backends:
   - Better performance for large datasets
   - Full-text search capabilities
   - More efficient memory usage
+  - Good for local deployments
 
-To switch between storage types, set the `STORAGE_TYPE` environment variable to either `json` or `sqlite` in your MCP configuration.
+- **MariaDB**: Production-ready database storage
+  - Uses a MariaDB/MySQL database server
+  - Ideal for large-scale deployments
+  - Full-text search capabilities
+  - Better scalability and concurrency support
+  - Suitable for deployments with high load or multiple concurrent users
+
+To switch between storage types, set the `STORAGE_TYPE` environment variable to `json`, `sqlite`, or `mariadb` in your MCP configuration.
 
 For detailed information about storage options, including how to convert between formats, see [Storage Switching](docs/storage-switching.md).
 
@@ -135,6 +182,33 @@ To use this server with Claude, add it to your MCP configuration file (e.g. `cla
         "LOAD_ALL_FILES": "true",
         "DEFAULT_PATH": "/memories",
         "STORAGE_TYPE": "sqlite",
+        "STRICT_MODE": "true"
+      },
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+For MariaDB configuration:
+
+```json
+{
+  "mcpServers": {
+    "memory-graph": {
+      "command": "node",
+      "args": ["/path/to/memory-graph/build/index.js"],
+      "env": {
+        "MEMORY_DIR": "/path/to/memory/storage",
+        "DEFAULT_PATH": "/memories",
+        "STORAGE_TYPE": "mariadb",
+        "MARIADB_HOST": "localhost",
+        "MARIADB_PORT": "3306",
+        "MARIADB_USER": "memory_user",
+        "MARIADB_PASSWORD": "secure_password",
+        "MARIADB_DATABASE": "memory_graph",
+        "MARIADB_CONNECTION_LIMIT": "10",
         "STRICT_MODE": "true"
       },
       "disabled": false,

--- a/docs/mariadb-schema.md
+++ b/docs/mariadb-schema.md
@@ -1,0 +1,265 @@
+# Memory Graph MariaDB Schema Documentation
+
+This document provides a complete reference for implementing the Memory Graph MCP schema in MariaDB. This schema can be used to create a compatible database for use with the MCP server or to build alternative tools that interact with Memory Graph data.
+
+## Schema Overview
+
+The Memory Graph database can be implemented in MariaDB with the following key components:
+
+1. **Core Tables**: For storing domains, memories, relationships, and state
+2. **Many-to-Many Relationship Tables**: For tags and cross-domain references
+3. **Full-Text Search**: Using MariaDB's FULLTEXT indexes instead of SQLite's FTS5
+4. **Indexes and Functions**: For performance and data integrity
+
+## Key Differences from SQLite
+
+When implementing the Memory Graph schema in MariaDB, there are several important differences from the SQLite version:
+
+1. **Full-Text Search**: MariaDB uses `FULLTEXT` indexes instead of SQLite's FTS5 virtual tables
+2. **Custom Functions**: MariaDB requires a custom function to concatenate tags for searching
+3. **View-Based Search**: A view is used to facilitate searching across content and tags
+4. **Data Types**: More specific data types are used (VARCHAR instead of TEXT for fixed-length fields)
+5. **Boolean Values**: MariaDB uses BOOLEAN type instead of INTEGER for boolean flags
+
+## Table Definitions
+
+### DOMAINS
+
+Stores information about memory domains (isolated memory contexts).
+
+```sql
+CREATE TABLE DOMAINS (
+    id VARCHAR(36) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    created VARCHAR(30) NOT NULL,
+    lastAccess VARCHAR(30) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+### PERSISTENCE
+
+Single-row table storing the system's current state. Only one row with `id = 1` should exist.
+
+```sql
+CREATE TABLE PERSISTENCE (
+    id INT PRIMARY KEY CHECK (id = 1),
+    currentDomain VARCHAR(36) NOT NULL,
+    lastAccess VARCHAR(30) NOT NULL,
+    lastMemoryId VARCHAR(36),
+    FOREIGN KEY (currentDomain) REFERENCES DOMAINS(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+### MEMORY_NODES
+
+Stores individual memory nodes with their content and metadata.
+
+```sql
+CREATE TABLE MEMORY_NODES (
+    id VARCHAR(36) PRIMARY KEY,
+    domain VARCHAR(36) NOT NULL,
+    content TEXT NOT NULL,
+    timestamp VARCHAR(30) NOT NULL,
+    path VARCHAR(255) DEFAULT '/',
+    content_summary TEXT,
+    summary_timestamp VARCHAR(30),
+    FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+### MEMORY_TAGS
+
+Many-to-many relationship table for memory node tags.
+
+```sql
+CREATE TABLE MEMORY_TAGS (
+    nodeId VARCHAR(36) NOT NULL,
+    tag VARCHAR(255) NOT NULL,
+    PRIMARY KEY (nodeId, tag),
+    FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+### MEMORY_EDGES
+
+Stores relationships between memory nodes.
+
+```sql
+CREATE TABLE MEMORY_EDGES (
+    id VARCHAR(255) PRIMARY KEY,
+    source VARCHAR(36) NOT NULL,
+    target VARCHAR(36) NOT NULL,
+    type VARCHAR(255) NOT NULL,
+    strength DECIMAL(3,2) NOT NULL CHECK (strength >= 0 AND strength <= 1),
+    timestamp VARCHAR(30) NOT NULL,
+    domain VARCHAR(36) NOT NULL,
+    FOREIGN KEY (source) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+    FOREIGN KEY (target) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+    FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+### DOMAIN_REFS
+
+Many-to-many relationship table for cross-domain references.
+
+```sql
+CREATE TABLE DOMAIN_REFS (
+    nodeId VARCHAR(36) NOT NULL,
+    domain VARCHAR(36) NOT NULL,
+    targetDomain VARCHAR(36) NOT NULL,
+    targetNodeId VARCHAR(36) NOT NULL,
+    description TEXT,
+    bidirectional BOOLEAN NOT NULL DEFAULT 0,
+    PRIMARY KEY (nodeId, targetDomain, targetNodeId),
+    FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+    FOREIGN KEY (domain) REFERENCES DOMAINS(id),
+    FOREIGN KEY (targetDomain) REFERENCES DOMAINS(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+## Indexes
+
+For optimal performance, the following indexes are created:
+
+```sql
+-- For fast domain-based filtering
+CREATE INDEX idx_memory_nodes_domain ON MEMORY_NODES(domain);
+
+-- For fast tag lookups
+CREATE INDEX idx_memory_tags_tag ON MEMORY_TAGS(tag);
+
+-- For fast edge traversal
+CREATE INDEX idx_memory_edges_source ON MEMORY_EDGES(source, domain);
+CREATE INDEX idx_memory_edges_target ON MEMORY_EDGES(target, domain);
+
+-- For fast domain reference lookups
+CREATE INDEX idx_domain_refs_target ON DOMAIN_REFS(targetDomain, targetNodeId);
+```
+
+## Full-Text Search Implementation
+
+MariaDB implements full-text search differently than SQLite. Instead of FTS5 virtual tables, MariaDB uses `FULLTEXT` indexes:
+
+```sql
+-- Full-text search index on content and summary
+ALTER TABLE MEMORY_NODES ADD FULLTEXT INDEX ft_memory_content (content, content_summary);
+```
+
+### Custom Function for Tag Concatenation
+
+To support searching with tags, we create a function to concatenate tags for a node:
+
+```sql
+DELIMITER //
+CREATE FUNCTION get_node_tags(node_id VARCHAR(36)) 
+RETURNS TEXT
+DETERMINISTIC
+BEGIN
+  DECLARE result TEXT;
+  SELECT GROUP_CONCAT(tag SEPARATOR ' ') INTO result FROM MEMORY_TAGS WHERE nodeId = node_id;
+  RETURN result;
+END //
+DELIMITER ;
+```
+
+### Search View
+
+We create a view that combines the memory content with its tags for comprehensive searching:
+
+```sql
+CREATE VIEW memory_content_search AS
+SELECT 
+    m.id,
+    m.content,
+    m.content_summary,
+    m.path,
+    m.domain,
+    get_node_tags(m.id) AS tags
+FROM MEMORY_NODES m;
+```
+
+## Searching Memory Content
+
+In MariaDB, full-text searches are performed using the `MATCH AGAINST` syntax:
+
+```sql
+-- Basic search on memory content
+SELECT m.* FROM MEMORY_NODES m
+WHERE MATCH(m.content, m.content_summary) AGAINST('search term' IN NATURAL LANGUAGE MODE);
+
+-- Search with tags using the view (if your MariaDB supports indexing views)
+SELECT * FROM memory_content_search 
+WHERE MATCH(content, content_summary, tags) AGAINST('search term' IN NATURAL LANGUAGE MODE);
+
+-- Alternative search with tags for older MariaDB versions
+SELECT m.*, get_node_tags(m.id) AS tags
+FROM MEMORY_NODES m
+WHERE 
+    MATCH(m.content, m.content_summary) AGAINST('search term' IN NATURAL LANGUAGE MODE)
+    OR get_node_tags(m.id) LIKE '%search term%';
+```
+
+## Creating a Compatible Database
+
+To create a compatible MariaDB database from scratch, use the provided script:
+
+```bash
+# Create and initialize the MariaDB database
+node scripts/create-mariadb-db.js
+```
+
+Or run the SQL script directly using the MariaDB CLI:
+
+```bash
+mysql -u username -p < scripts/create-mariadb-schema.sql
+```
+
+## Data Formats
+
+### Timestamps
+
+All timestamps in the database should be stored in ISO 8601 format (e.g., `2023-04-15T10:30:45.123Z`).
+
+### IDs
+
+- Domain IDs: Typically UUIDs as text strings (VARCHAR(36))
+- Memory node IDs: Typically UUIDs as text strings (VARCHAR(36))
+- Edge IDs: Composite ID formed by combining `source-target-type` (VARCHAR(255))
+
+## Performance Considerations
+
+For optimal performance in MariaDB:
+
+1. **InnoDB Buffer Pool**: Configure appropriate buffer pool size for your server
+   ```sql
+   SET GLOBAL innodb_buffer_pool_size = 1G; -- Adjust based on available RAM
+   ```
+
+2. **Character Set**: Use utf8mb4 charset and collation for proper Unicode support
+   ```sql
+   SET NAMES utf8mb4;
+   SET SESSION character_set_client = utf8mb4;
+   SET SESSION character_set_connection = utf8mb4;
+   SET SESSION character_set_results = utf8mb4;
+   SET SESSION collation_connection = utf8mb4_unicode_ci;
+   ```
+
+3. **Transaction Isolation**: Consider the appropriate isolation level for your use case
+   ```sql
+   SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+   ```
+
+## Compatibility Notes
+
+This MariaDB schema is designed to be compatible with the Memory Graph MCP's expected data model. To ensure compatibility:
+
+1. Keep the table structure and relationships identical to the SQLite schema
+2. Ensure all queries use the appropriate syntax for MariaDB
+3. Test full-text search functionality thoroughly
+4. Use the provided example code for reference
+
+## Schema Version
+
+This schema documentation is based on Memory Graph MCP as of May 2025.

--- a/docs/sqlite-schema-README.md
+++ b/docs/sqlite-schema-README.md
@@ -1,0 +1,93 @@
+# Memory Graph SQLite Schema
+
+This directory contains documentation and scripts for working with the Memory Graph MCP SQLite schema independently from the MCP server.
+
+## Overview
+
+Memory Graph MCP uses a SQLite database to store domain-based memory contexts and their relationships. This schema enables:
+
+1. **Domain-based memory organization** - Isolated memory contexts
+2. **Memory node storage** - Store memories with content, tags, and path structure
+3. **Relationship tracking** - Connect related memories with typed relationships
+4. **Cross-domain references** - Connect memories across domain boundaries
+5. **Full-text search** - Find memories based on content using SQLite FTS5
+
+## Documentation
+
+- `sqlite-schema.md` - Complete schema documentation with all table definitions, indexes, and triggers
+- `scripts/create-sqlite-db.js` - JavaScript example for creating and using a compatible database
+- `scripts/create-sqlite-db.ts` - TypeScript example for creating and using a compatible database
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 14+ 
+- SQLite 3.31.0+ with FTS5 support
+
+### Creating a Database
+
+You can create a compatible database using the provided scripts:
+
+```bash
+# JavaScript version
+node scripts/create-sqlite-db.js
+
+# TypeScript version
+ts-node scripts/create-sqlite-db.ts
+```
+
+The scripts will:
+1. Create a new SQLite database file
+2. Initialize the schema with all tables, indexes, and triggers
+3. Create a sample domain
+4. Add sample memory nodes with relationships
+5. Demonstrate a basic full-text search
+
+### Schema Structure
+
+The database uses these main tables:
+
+1. **DOMAINS** - Stores domain information
+2. **PERSISTENCE** - Single-row table for system state
+3. **MEMORY_NODES** - Stores individual memory nodes
+4. **MEMORY_TAGS** - Many-to-many table for node tags
+5. **MEMORY_EDGES** - Stores relationships between nodes
+6. **DOMAIN_REFS** - Cross-domain references
+7. **memory_content_fts** - Virtual FTS5 table for full-text search
+
+## Integration
+
+To integrate this schema with your own applications:
+
+1. Follow the table definitions in `sqlite-schema.md`
+2. Ensure all triggers and indexes are created
+3. Use the sample scripts as a reference for basic operations
+
+## Features and Capabilities
+
+When using this schema, you can:
+
+- Create isolated memory domains
+- Store memories with rich content and metadata
+- Establish typed relationships between memories
+- Create cross-domain references
+- Perform full-text search across memory content and tags
+- Organize memories hierarchically with paths
+
+## Additional Resources
+
+For more detailed information, see:
+
+- `sqlite-schema.md` - Complete schema documentation
+- `memoryArchitecture.md` - Overall memory architecture design
+- `MemoryGraph.ts` - Main interface implementation in the MCP
+- `SqliteMemoryStorage.ts` - Storage implementation that uses this schema
+
+## Version Compatibility
+
+This schema documentation and the sample scripts are compatible with Memory Graph MCP as of May 2025. Future versions may include schema changes.
+
+## License
+
+This schema documentation and the accompanying scripts are provided under the same license as the Memory Graph MCP project.

--- a/docs/sqlite-schema.md
+++ b/docs/sqlite-schema.md
@@ -1,0 +1,341 @@
+# Memory Graph SQLite Schema Documentation
+
+This document provides a complete reference for the SQLite database schema used by Memory Graph MCP. This schema can be independently implemented to create a compatible database for use with the MCP server or to build alternative tools that interact with Memory Graph data.
+
+## Schema Overview
+
+The Memory Graph database uses SQLite with the following key components:
+
+1. **Core Tables**: For storing domains, memories, relationships, and state
+2. **Many-to-Many Relationship Tables**: For tags and cross-domain references
+3. **Full-Text Search**: Using SQLite's FTS5 extension for content searching
+4. **Indexes and Triggers**: For performance and data integrity
+
+## Table Definitions
+
+### DOMAINS
+
+Stores information about memory domains (isolated memory contexts).
+
+```sql
+CREATE TABLE DOMAINS (
+    id TEXT PRIMARY KEY,              -- Unique domain identifier
+    name TEXT NOT NULL,               -- Human-readable name
+    description TEXT,                 -- Purpose/scope of the domain
+    created TEXT NOT NULL,            -- ISO timestamp
+    lastAccess TEXT NOT NULL          -- ISO timestamp
+);
+```
+
+### PERSISTENCE
+
+Single-row table storing the system's current state. Only one row with `id = 1` should exist.
+
+```sql
+CREATE TABLE PERSISTENCE (
+    id INTEGER PRIMARY KEY CHECK (id = 1), -- Enforces single row
+    currentDomain TEXT NOT NULL,           -- Currently active domain
+    lastAccess TEXT NOT NULL,              -- ISO timestamp
+    lastMemoryId TEXT,                     -- Most recently created memory (optional)
+    FOREIGN KEY (currentDomain) REFERENCES DOMAINS(id)
+);
+```
+
+### MEMORY_NODES
+
+Stores individual memory nodes with their content and metadata.
+
+```sql
+CREATE TABLE MEMORY_NODES (
+    id TEXT PRIMARY KEY,          -- Unique memory identifier
+    domain TEXT NOT NULL,         -- Domain this memory belongs to
+    content TEXT NOT NULL,        -- Main memory content
+    timestamp TEXT NOT NULL,      -- ISO timestamp of creation
+    path TEXT DEFAULT '/',        -- Organizational path
+    content_summary TEXT,         -- Optional summary of the content
+    summary_timestamp TEXT,       -- When the summary was last updated
+    FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+);
+```
+
+### MEMORY_TAGS
+
+Many-to-many relationship table for memory node tags.
+
+```sql
+CREATE TABLE MEMORY_TAGS (
+    nodeId TEXT NOT NULL,         -- Memory node ID
+    tag TEXT NOT NULL,            -- Tag value
+    PRIMARY KEY (nodeId, tag),    -- Prevents duplicate tags
+    FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE
+);
+```
+
+### MEMORY_EDGES
+
+Stores relationships between memory nodes.
+
+```sql
+CREATE TABLE MEMORY_EDGES (
+    id TEXT PRIMARY KEY,          -- Composite edge ID (source-target-type)
+    source TEXT NOT NULL,         -- Source memory node ID
+    target TEXT NOT NULL,         -- Target memory node ID
+    type TEXT NOT NULL,           -- Relationship type
+    strength REAL NOT NULL CHECK (strength >= 0 AND strength <= 1), -- Relationship strength (0-1)
+    timestamp TEXT NOT NULL,      -- ISO timestamp
+    domain TEXT NOT NULL,         -- Domain this edge belongs to
+    FOREIGN KEY (source) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+    FOREIGN KEY (target) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+    FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+);
+```
+
+### DOMAIN_REFS
+
+Many-to-many relationship table for cross-domain references.
+
+```sql
+CREATE TABLE DOMAIN_REFS (
+    nodeId TEXT NOT NULL,         -- Source memory node ID
+    domain TEXT NOT NULL,         -- Source domain
+    targetDomain TEXT NOT NULL,   -- Target domain
+    targetNodeId TEXT NOT NULL,   -- Target memory node ID
+    description TEXT,             -- Optional reference description
+    bidirectional INTEGER NOT NULL DEFAULT 0, -- 0=one-way, 1=bidirectional
+    PRIMARY KEY (nodeId, targetDomain, targetNodeId), -- Prevents duplicates
+    FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+    FOREIGN KEY (domain) REFERENCES DOMAINS(id),
+    FOREIGN KEY (targetDomain) REFERENCES DOMAINS(id)
+);
+```
+
+## Indexes
+
+For optimal performance, the following indexes are created:
+
+```sql
+-- For fast domain-based filtering
+CREATE INDEX idx_memory_nodes_domain ON MEMORY_NODES(domain);
+
+-- For fast tag lookups
+CREATE INDEX idx_memory_tags_tag ON MEMORY_TAGS(tag);
+
+-- For fast edge traversal
+CREATE INDEX idx_memory_edges_source ON MEMORY_EDGES(source, domain);
+CREATE INDEX idx_memory_edges_target ON MEMORY_EDGES(target, domain);
+
+-- For fast domain reference lookups
+CREATE INDEX idx_domain_refs_target ON DOMAIN_REFS(targetDomain, targetNodeId);
+```
+
+## Full-Text Search
+
+The SQLite implementation uses FTS5 for full-text search capabilities:
+
+```sql
+-- Enable FTS5 extension for full-text search
+CREATE VIRTUAL TABLE memory_content_fts USING fts5(
+    id,              -- Memory ID
+    content,         -- Memory content
+    content_summary, -- Memory summary
+    path,            -- Organization path
+    tags,            -- Concatenated tags for searching
+    domain,          -- Domain ID
+    tokenize="porter unicode61"  -- Use Porter stemming algorithm
+);
+```
+
+## Triggers
+
+Triggers keep the FTS index in sync with the main tables:
+
+```sql
+-- Insert trigger for memory nodes
+CREATE TRIGGER memory_nodes_ai AFTER INSERT ON MEMORY_NODES BEGIN
+    INSERT INTO memory_content_fts(id, content, content_summary, path, domain)
+    VALUES (new.id, new.content, new.content_summary, new.path, new.domain);
+END;
+
+-- Delete trigger for memory nodes
+CREATE TRIGGER memory_nodes_ad AFTER DELETE ON MEMORY_NODES BEGIN
+    DELETE FROM memory_content_fts WHERE id = old.id;
+END;
+
+-- Update trigger for memory nodes
+CREATE TRIGGER memory_nodes_au AFTER UPDATE ON MEMORY_NODES BEGIN
+    DELETE FROM memory_content_fts WHERE id = old.id;
+    INSERT INTO memory_content_fts(id, content, content_summary, path, domain)
+    VALUES (new.id, new.content, new.content_summary, new.path, new.domain);
+END;
+
+-- Insert trigger for memory tags (to update FTS index)
+CREATE TRIGGER memory_tags_ai AFTER INSERT ON MEMORY_TAGS BEGIN
+    UPDATE memory_content_fts 
+    SET tags = (SELECT group_concat(tag, ' ') FROM MEMORY_TAGS WHERE nodeId = new.nodeId)
+    WHERE id = new.nodeId;
+END;
+
+-- Delete trigger for memory tags (to update FTS index)
+CREATE TRIGGER memory_tags_ad AFTER DELETE ON MEMORY_TAGS BEGIN
+    UPDATE memory_content_fts 
+    SET tags = (SELECT group_concat(tag, ' ') FROM MEMORY_TAGS WHERE nodeId = old.nodeId)
+    WHERE id = old.nodeId;
+END;
+```
+
+## Creating a Compatible Database
+
+To create a compatible SQLite database from scratch, you can use this initialization script:
+
+```sql
+-- Enable foreign keys
+PRAGMA foreign_keys = ON;
+
+-- Create tables
+-- Domains table
+CREATE TABLE DOMAINS (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    created TEXT NOT NULL,
+    lastAccess TEXT NOT NULL
+);
+
+-- Persistence state table (single row)
+CREATE TABLE PERSISTENCE (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    currentDomain TEXT NOT NULL,
+    lastAccess TEXT NOT NULL,
+    lastMemoryId TEXT,
+    FOREIGN KEY (currentDomain) REFERENCES DOMAINS(id)
+);
+
+-- Memory nodes table
+CREATE TABLE MEMORY_NODES (
+    id TEXT PRIMARY KEY,
+    domain TEXT NOT NULL,
+    content TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    path TEXT DEFAULT '/',
+    content_summary TEXT,
+    summary_timestamp TEXT,
+    FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+);
+
+-- Memory tags table (many-to-many)
+CREATE TABLE MEMORY_TAGS (
+    nodeId TEXT NOT NULL,
+    tag TEXT NOT NULL,
+    PRIMARY KEY (nodeId, tag),
+    FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE
+);
+
+-- Memory edges table
+CREATE TABLE MEMORY_EDGES (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL,
+    target TEXT NOT NULL,
+    type TEXT NOT NULL,
+    strength REAL NOT NULL CHECK (strength >= 0 AND strength <= 1),
+    timestamp TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    FOREIGN KEY (source) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+    FOREIGN KEY (target) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+    FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+);
+
+-- Domain references table
+CREATE TABLE DOMAIN_REFS (
+    nodeId TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    targetDomain TEXT NOT NULL,
+    targetNodeId TEXT NOT NULL,
+    description TEXT,
+    bidirectional INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (nodeId, targetDomain, targetNodeId),
+    FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+    FOREIGN KEY (domain) REFERENCES DOMAINS(id),
+    FOREIGN KEY (targetDomain) REFERENCES DOMAINS(id)
+);
+
+-- Create indexes
+-- For fast domain-based filtering
+CREATE INDEX idx_memory_nodes_domain ON MEMORY_NODES(domain);
+
+-- For fast tag lookups
+CREATE INDEX idx_memory_tags_tag ON MEMORY_TAGS(tag);
+
+-- For fast edge traversal
+CREATE INDEX idx_memory_edges_source ON MEMORY_EDGES(source, domain);
+CREATE INDEX idx_memory_edges_target ON MEMORY_EDGES(target, domain);
+
+-- For fast domain reference lookups
+CREATE INDEX idx_domain_refs_target ON DOMAIN_REFS(targetDomain, targetNodeId);
+
+-- Create FTS virtual table and triggers
+-- Enable FTS5 extension for full-text search
+CREATE VIRTUAL TABLE memory_content_fts USING fts5(
+    id,              -- Memory ID
+    content,         -- Memory content
+    content_summary, -- Memory summary
+    path,            -- Organization path
+    tags,            -- Concatenated tags for searching
+    domain,          -- Domain ID
+    tokenize="porter unicode61"  -- Use Porter stemming algorithm
+);
+
+-- Triggers to keep FTS index in sync with memory nodes
+CREATE TRIGGER memory_nodes_ai AFTER INSERT ON MEMORY_NODES BEGIN
+    INSERT INTO memory_content_fts(id, content, content_summary, path, domain)
+    VALUES (new.id, new.content, new.content_summary, new.path, new.domain);
+END;
+
+CREATE TRIGGER memory_nodes_ad AFTER DELETE ON MEMORY_NODES BEGIN
+    DELETE FROM memory_content_fts WHERE id = old.id;
+END;
+
+CREATE TRIGGER memory_nodes_au AFTER UPDATE ON MEMORY_NODES BEGIN
+    DELETE FROM memory_content_fts WHERE id = old.id;
+    INSERT INTO memory_content_fts(id, content, content_summary, path, domain)
+    VALUES (new.id, new.content, new.content_summary, new.path, new.domain);
+END;
+
+-- Trigger to update tags in FTS when tags are added/removed
+CREATE TRIGGER memory_tags_ai AFTER INSERT ON MEMORY_TAGS BEGIN
+    UPDATE memory_content_fts 
+    SET tags = (SELECT group_concat(tag, ' ') FROM MEMORY_TAGS WHERE nodeId = new.nodeId)
+    WHERE id = new.nodeId;
+END;
+
+CREATE TRIGGER memory_tags_ad AFTER DELETE ON MEMORY_TAGS BEGIN
+    UPDATE memory_content_fts 
+    SET tags = (SELECT group_concat(tag, ' ') FROM MEMORY_TAGS WHERE nodeId = old.nodeId)
+    WHERE id = old.nodeId;
+END;
+```
+
+## Data Formats
+
+### Timestamps
+
+All timestamps in the database should be stored in ISO 8601 format (e.g., `2023-04-15T10:30:45.123Z`).
+
+### IDs
+
+- Domain IDs: Typically UUIDs as text strings
+- Memory node IDs: Typically UUIDs as text strings
+- Edge IDs: Composite ID formed by combining `source-target-type`
+
+## Using the Schema with External Tools
+
+When using this schema with external tools or custom implementations:
+
+1. Ensure SQLite is compiled with FTS5 extension support
+2. Maintain referential integrity between tables
+3. Always use transactions when making multiple related changes
+4. Preserve the trigger logic for FTS updates
+5. Follow the ID generation and timestamp format conventions
+
+## Schema Version
+
+This schema documentation is based on Memory Graph MCP as of May 2025.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,14 @@
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.0",
+        "express": "^5.1.0",
+        "mysql2": "^3.9.1",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
         "typescript": "^5.0.0"
       },
       "devDependencies": {
+        "@types/express": "^5.0.1",
         "@types/jest": "^29.0.0",
         "@types/node": "^22.14.1",
         "jest": "^29.0.0",
@@ -1095,6 +1098,52 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.1.tgz",
+      "integrity": "sha512-UZUw8vjpWFXuDnjFTh7/5c2TWDlQqeXHi6hcN7F2XSVT5P+WmUnnbFS3KA6Jnc6IsEqI2qCVu2bK0R0J4A8ZQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1104,6 +1153,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -1143,6 +1199,13 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.14.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
@@ -1151,6 +1214,43 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.18",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1364,6 +1464,15 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2109,6 +2218,15 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2679,6 +2797,15 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3133,6 +3260,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
     },
     "node_modules/is-stream": {
@@ -3961,6 +4094,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3969,6 +4108,21 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.2.tgz",
+      "integrity": "sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/make-dir": {
@@ -4321,6 +4475,47 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mysql2": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.14.1.tgz",
+      "integrity": "sha512-7ytuPQJjQB8TNAYX/H2yhL+iQOnIBjAMam361R7UAL0lOVXWjtdrmoL9HYKqKoLp/8UUTRcvo1QPvK9KL7wA8w==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/named-placeholders/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
@@ -5114,6 +5309,11 @@
         "node": ">= 18"
       }
     },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
     "node_modules/serve-static": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
@@ -5401,6 +5601,15 @@
         "node-gyp": {
           "optional": true
         }
+      }
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/ssri": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
+    "mysql2": "^3.9.1",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
     "typescript": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -22,12 +22,14 @@
   "license": "ISC",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
+    "express": "^5.1.0",
     "mysql2": "^3.9.1",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
     "typescript": "^5.0.0"
   },
   "devDependencies": {
+    "@types/express": "^5.0.1",
     "@types/jest": "^29.0.0",
     "@types/node": "^22.14.1",
     "jest": "^29.0.0",

--- a/scripts/create-mariadb-db.js
+++ b/scripts/create-mariadb-db.js
@@ -1,0 +1,229 @@
+/**
+ * Example script to create and initialize a Memory Graph MariaDB database
+ * This can be used independently of the main MCP server
+ */
+
+const fs = require('fs');
+const path = require('path');
+const mysql = require('mysql2/promise');
+const { v4: uuidv4 } = require('uuid');
+
+// Database connection configuration
+const DB_CONFIG = {
+  host: 'localhost',
+  user: 'root',      // Change to your MariaDB username
+  password: '',      // Change to your MariaDB password
+  database: 'memory_graph',
+  multipleStatements: true,
+  waitForConnections: true,
+  connectionLimit: 10,
+  queueLimit: 0
+};
+
+/**
+ * Initialize database and create tables
+ * @param {mysql.Connection} connection - MariaDB connection
+ */
+async function initializeSchema(connection) {
+  console.log('Creating schema...');
+  
+  // Read the SQL schema file
+  const schemaPath = path.join(__dirname, 'create-mariadb-schema.sql');
+  const schema = fs.readFileSync(schemaPath, 'utf8');
+  
+  // Split and execute the SQL statements
+  // Note: This simple approach may not handle all SQL syntax correctly
+  // For production, use a proper SQL parser/migration tool
+  const statements = schema.split(';')
+    .map(statement => statement.trim())
+    .filter(statement => statement.length > 0);
+  
+  for (const statement of statements) {
+    await connection.query(statement);
+  }
+  
+  console.log('Schema created successfully');
+}
+
+/**
+ * Create a sample domain
+ * @param {mysql.Connection} connection - MariaDB connection
+ * @returns {string} - The created domain ID
+ */
+async function createSampleDomain(connection) {
+  const now = new Date().toISOString();
+  const domainId = uuidv4();
+  
+  await connection.query(
+    'INSERT INTO DOMAINS (id, name, description, created, lastAccess) VALUES (?, ?, ?, ?, ?)',
+    [domainId, 'Sample Domain', 'A sample domain for testing', now, now]
+  );
+  
+  // Check if persistence state exists
+  const [persistenceRows] = await connection.query('SELECT 1 FROM PERSISTENCE WHERE id = 1');
+  
+  if (persistenceRows.length > 0) {
+    await connection.query(
+      'UPDATE PERSISTENCE SET currentDomain = ?, lastAccess = ? WHERE id = 1',
+      [domainId, now]
+    );
+  } else {
+    await connection.query(
+      'INSERT INTO PERSISTENCE (id, currentDomain, lastAccess) VALUES (1, ?, ?)',
+      [domainId, now]
+    );
+  }
+  
+  console.log(`Created domain: ${domainId}`);
+  return domainId;
+}
+
+/**
+ * Add sample memories with relationships
+ * @param {mysql.Connection} connection - MariaDB connection
+ * @param {string} domainId - Domain ID
+ */
+async function addSampleMemories(connection, domainId) {
+  const now = new Date().toISOString();
+  
+  // Create first memory node
+  const node1Id = uuidv4();
+  await connection.query(
+    'INSERT INTO MEMORY_NODES (id, domain, content, timestamp, path, content_summary) VALUES (?, ?, ?, ?, ?, ?)',
+    [
+      node1Id,
+      domainId,
+      'This is the first memory node with important information about the project.',
+      now,
+      '/projects',
+      'First memory with project info'
+    ]
+  );
+  
+  // Add tags to first node
+  await connection.query('INSERT INTO MEMORY_TAGS (nodeId, tag) VALUES (?, ?)', [node1Id, 'project']);
+  await connection.query('INSERT INTO MEMORY_TAGS (nodeId, tag) VALUES (?, ?)', [node1Id, 'important']);
+  
+  // Create second memory node
+  const node2Id = uuidv4();
+  await connection.query(
+    'INSERT INTO MEMORY_NODES (id, domain, content, timestamp, path) VALUES (?, ?, ?, ?, ?)',
+    [
+      node2Id,
+      domainId,
+      'This is the second memory node with related details to the first node.',
+      now,
+      '/projects/details'
+    ]
+  );
+  
+  // Add tags to second node
+  await connection.query('INSERT INTO MEMORY_TAGS (nodeId, tag) VALUES (?, ?)', [node2Id, 'details']);
+  
+  // Create edge between nodes
+  const edgeId = `${node1Id}-${node2Id}-related_to`;
+  await connection.query(
+    'INSERT INTO MEMORY_EDGES (id, source, target, type, strength, timestamp, domain) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    [edgeId, node1Id, node2Id, 'related_to', 0.8, now, domainId]
+  );
+  
+  // Update persistence with latest memory
+  await connection.query(
+    'UPDATE PERSISTENCE SET lastMemoryId = ? WHERE id = 1',
+    [node2Id]
+  );
+  
+  console.log(`Added sample memories: ${node1Id}, ${node2Id} with relationship`);
+}
+
+/**
+ * Perform a sample full-text search using MariaDB MATCH AGAINST
+ * @param {mysql.Connection} connection - MariaDB connection
+ * @param {string} query - Search query
+ */
+async function performSearch(connection, query) {
+  console.log(`Searching for: "${query}"`);
+  
+  // In MariaDB, we use MATCH AGAINST for full-text search
+  const [rows] = await connection.query(`
+    SELECT m.*, get_node_tags(m.id) AS tags_concat
+    FROM MEMORY_NODES m
+    WHERE MATCH(m.content, m.content_summary) AGAINST(? IN NATURAL LANGUAGE MODE)
+    LIMIT 10
+  `, [query]);
+  
+  console.log(`Found ${rows.length} results:`);
+  
+  for (const row of rows) {
+    // Get tags for this node
+    const [tagRows] = await connection.query('SELECT tag FROM MEMORY_TAGS WHERE nodeId = ?', [row.id]);
+    const tags = tagRows.map(t => t.tag);
+    
+    console.log(`- ID: ${row.id}`);
+    console.log(`  Content: ${row.content.substring(0, 50)}${row.content.length > 50 ? '...' : ''}`);
+    console.log(`  Path: ${row.path}`);
+    console.log(`  Tags: ${tags.join(', ')}`);
+    console.log(`  Summary: ${row.content_summary || 'N/A'}`);
+    console.log('-----------------------------');
+  }
+}
+
+/**
+ * Create the database if it doesn't exist
+ */
+async function createDatabase() {
+  // Create a connection without specifying a database
+  const tempConnection = await mysql.createConnection({
+    host: DB_CONFIG.host,
+    user: DB_CONFIG.user,
+    password: DB_CONFIG.password
+  });
+  
+  try {
+    console.log(`Creating database: ${DB_CONFIG.database}`);
+    await tempConnection.query(`CREATE DATABASE IF NOT EXISTS ${DB_CONFIG.database} 
+                               CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci`);
+  } finally {
+    await tempConnection.end();
+  }
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  // Create the database if it doesn't exist
+  await createDatabase();
+  
+  // Create a connection pool
+  const pool = mysql.createPool(DB_CONFIG);
+  let connection;
+  
+  try {
+    // Get a connection from the pool
+    connection = await pool.getConnection();
+    
+    // Initialize schema
+    await initializeSchema(connection);
+    
+    // Create sample data
+    const domainId = await createSampleDomain(connection);
+    await addSampleMemories(connection, domainId);
+    
+    // Perform a sample search
+    await performSearch(connection, 'project');
+    
+    console.log('Database setup complete!');
+  } catch (error) {
+    console.error('Error:', error);
+  } finally {
+    // Release the connection back to the pool
+    if (connection) connection.release();
+    
+    // Close the pool
+    await pool.end();
+  }
+}
+
+// Run the script
+main().catch(console.error);

--- a/scripts/create-mariadb-schema.sql
+++ b/scripts/create-mariadb-schema.sql
@@ -1,0 +1,143 @@
+-- MariaDB Schema for Memory Graph MCP
+-- Compatible with the SQLite implementation
+
+-- Enable foreign key constraints
+SET FOREIGN_KEY_CHECKS=1;
+
+-- Create tables
+-- Domains table
+CREATE TABLE IF NOT EXISTS DOMAINS (
+    id VARCHAR(36) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    created VARCHAR(30) NOT NULL,
+    lastAccess VARCHAR(30) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Persistence state table (single row)
+CREATE TABLE IF NOT EXISTS PERSISTENCE (
+    id INT PRIMARY KEY CHECK (id = 1),
+    currentDomain VARCHAR(36) NOT NULL,
+    lastAccess VARCHAR(30) NOT NULL,
+    lastMemoryId VARCHAR(36),
+    FOREIGN KEY (currentDomain) REFERENCES DOMAINS(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Memory nodes table
+CREATE TABLE IF NOT EXISTS MEMORY_NODES (
+    id VARCHAR(36) PRIMARY KEY,
+    domain VARCHAR(36) NOT NULL,
+    content TEXT NOT NULL,
+    timestamp VARCHAR(30) NOT NULL,
+    path VARCHAR(255) DEFAULT '/',
+    content_summary TEXT,
+    summary_timestamp VARCHAR(30),
+    FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Memory tags table (many-to-many)
+CREATE TABLE IF NOT EXISTS MEMORY_TAGS (
+    nodeId VARCHAR(36) NOT NULL,
+    tag VARCHAR(255) NOT NULL,
+    PRIMARY KEY (nodeId, tag),
+    FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Memory edges table
+CREATE TABLE IF NOT EXISTS MEMORY_EDGES (
+    id VARCHAR(255) PRIMARY KEY,
+    source VARCHAR(36) NOT NULL,
+    target VARCHAR(36) NOT NULL,
+    type VARCHAR(255) NOT NULL,
+    strength DECIMAL(3,2) NOT NULL CHECK (strength >= 0 AND strength <= 1),
+    timestamp VARCHAR(30) NOT NULL,
+    domain VARCHAR(36) NOT NULL,
+    FOREIGN KEY (source) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+    FOREIGN KEY (target) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+    FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Domain references table
+CREATE TABLE IF NOT EXISTS DOMAIN_REFS (
+    nodeId VARCHAR(36) NOT NULL,
+    domain VARCHAR(36) NOT NULL,
+    targetDomain VARCHAR(36) NOT NULL,
+    targetNodeId VARCHAR(36) NOT NULL,
+    description TEXT,
+    bidirectional BOOLEAN NOT NULL DEFAULT 0,
+    PRIMARY KEY (nodeId, targetDomain, targetNodeId),
+    FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+    FOREIGN KEY (domain) REFERENCES DOMAINS(id),
+    FOREIGN KEY (targetDomain) REFERENCES DOMAINS(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Create indexes
+-- For fast domain-based filtering
+CREATE INDEX idx_memory_nodes_domain ON MEMORY_NODES(domain);
+
+-- For fast tag lookups
+CREATE INDEX idx_memory_tags_tag ON MEMORY_TAGS(tag);
+
+-- For fast edge traversal
+CREATE INDEX idx_memory_edges_source ON MEMORY_EDGES(source, domain);
+CREATE INDEX idx_memory_edges_target ON MEMORY_EDGES(target, domain);
+
+-- For fast domain reference lookups
+CREATE INDEX idx_domain_refs_target ON DOMAIN_REFS(targetDomain, targetNodeId);
+
+-- Full-text search indexes
+-- MariaDB uses FULLTEXT indexes instead of FTS5 virtual tables
+ALTER TABLE MEMORY_NODES ADD FULLTEXT INDEX ft_memory_content (content, content_summary);
+
+-- Create concatenated tags function and view for searching
+DELIMITER //
+CREATE OR REPLACE FUNCTION get_node_tags(node_id VARCHAR(36)) 
+RETURNS TEXT
+DETERMINISTIC
+BEGIN
+  DECLARE result TEXT;
+  SELECT GROUP_CONCAT(tag SEPARATOR ' ') INTO result FROM MEMORY_TAGS WHERE nodeId = node_id;
+  RETURN result;
+END //
+DELIMITER ;
+
+-- Create a view that combines memory node content with tags for full-text searching
+CREATE OR REPLACE VIEW memory_content_search AS
+SELECT 
+    m.id,
+    m.content,
+    m.content_summary,
+    m.path,
+    m.domain,
+    get_node_tags(m.id) AS tags
+FROM MEMORY_NODES m;
+
+-- Add FULLTEXT index to the view if your MariaDB version supports indexing views
+-- If not supported, you'll need to use JOINs in your queries
+-- ALTER TABLE memory_content_search ADD FULLTEXT INDEX ft_memory_content_full (content, content_summary, tags);
+
+-- Create triggers to maintain the concatenated tags in the full-text index
+DELIMITER //
+
+-- Insert trigger for memory nodes (not needed in MariaDB as the view handles this)
+
+-- Update trigger for memory tags (not needed in MariaDB as the function handles this)
+
+-- NOTE: In MariaDB, the view and function will automatically update with the underlying table changes
+-- so explicit triggers to update FTS indexes like in SQLite are not needed
+
+DELIMITER ;
+
+-- Additional MariaDB-specific optimizations
+-- Set the transaction isolation level for better performance
+SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+-- Optional: Optimize for memory usage if run on a server with sufficient RAM
+-- SET GLOBAL innodb_buffer_pool_size = 1G; -- Adjust based on available RAM
+
+-- Set character set and collation explicitly
+SET NAMES utf8mb4;
+SET SESSION character_set_client = utf8mb4;
+SET SESSION character_set_connection = utf8mb4;
+SET SESSION character_set_results = utf8mb4;
+SET SESSION collation_connection = utf8mb4_unicode_ci;

--- a/scripts/create-sqlite-db.js
+++ b/scripts/create-sqlite-db.js
@@ -1,0 +1,310 @@
+/**
+ * Example script to create and initialize a Memory Graph SQLite database
+ * This can be used independently of the main MCP server
+ */
+
+const sqlite3 = require('sqlite3');
+const { open } = require('sqlite');
+const { v4: uuidv4 } = require('uuid');
+const path = require('path');
+
+// Database file path
+const DB_PATH = path.join(process.cwd(), 'memory-graph-example.db');
+
+/**
+ * Initialize the database schema
+ * @param {object} db - SQLite database connection
+ */
+async function initializeSchema(db) {
+  console.log('Creating schema...');
+  
+  // Create tables and indexes
+  await db.exec(`
+    -- Enable foreign keys
+    PRAGMA foreign_keys = ON;
+
+    -- Create tables
+    -- Domains table
+    CREATE TABLE IF NOT EXISTS DOMAINS (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT,
+        created TEXT NOT NULL,
+        lastAccess TEXT NOT NULL
+    );
+
+    -- Persistence state table (single row)
+    CREATE TABLE IF NOT EXISTS PERSISTENCE (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        currentDomain TEXT NOT NULL,
+        lastAccess TEXT NOT NULL,
+        lastMemoryId TEXT,
+        FOREIGN KEY (currentDomain) REFERENCES DOMAINS(id)
+    );
+
+    -- Memory nodes table
+    CREATE TABLE IF NOT EXISTS MEMORY_NODES (
+        id TEXT PRIMARY KEY,
+        domain TEXT NOT NULL,
+        content TEXT NOT NULL,
+        timestamp TEXT NOT NULL,
+        path TEXT DEFAULT '/',
+        content_summary TEXT,
+        summary_timestamp TEXT,
+        FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+    );
+
+    -- Memory tags table (many-to-many)
+    CREATE TABLE IF NOT EXISTS MEMORY_TAGS (
+        nodeId TEXT NOT NULL,
+        tag TEXT NOT NULL,
+        PRIMARY KEY (nodeId, tag),
+        FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE
+    );
+
+    -- Memory edges table
+    CREATE TABLE IF NOT EXISTS MEMORY_EDGES (
+        id TEXT PRIMARY KEY,
+        source TEXT NOT NULL,
+        target TEXT NOT NULL,
+        type TEXT NOT NULL,
+        strength REAL NOT NULL CHECK (strength >= 0 AND strength <= 1),
+        timestamp TEXT NOT NULL,
+        domain TEXT NOT NULL,
+        FOREIGN KEY (source) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+        FOREIGN KEY (target) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+        FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+    );
+
+    -- Domain references table
+    CREATE TABLE IF NOT EXISTS DOMAIN_REFS (
+        nodeId TEXT NOT NULL,
+        domain TEXT NOT NULL,
+        targetDomain TEXT NOT NULL,
+        targetNodeId TEXT NOT NULL,
+        description TEXT,
+        bidirectional INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (nodeId, targetDomain, targetNodeId),
+        FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+        FOREIGN KEY (domain) REFERENCES DOMAINS(id),
+        FOREIGN KEY (targetDomain) REFERENCES DOMAINS(id)
+    );
+
+    -- Create indexes
+    -- For fast domain-based filtering
+    CREATE INDEX IF NOT EXISTS idx_memory_nodes_domain ON MEMORY_NODES(domain);
+
+    -- For fast tag lookups
+    CREATE INDEX IF NOT EXISTS idx_memory_tags_tag ON MEMORY_TAGS(tag);
+
+    -- For fast edge traversal
+    CREATE INDEX IF NOT EXISTS idx_memory_edges_source ON MEMORY_EDGES(source, domain);
+    CREATE INDEX IF NOT EXISTS idx_memory_edges_target ON MEMORY_EDGES(target, domain);
+
+    -- For fast domain reference lookups
+    CREATE INDEX IF NOT EXISTS idx_domain_refs_target ON DOMAIN_REFS(targetDomain, targetNodeId);
+  `);
+
+  // Create FTS5 table and triggers
+  await db.exec(`
+    -- Enable FTS5 extension for full-text search
+    CREATE VIRTUAL TABLE IF NOT EXISTS memory_content_fts USING fts5(
+        id,              -- Memory ID
+        content,         -- Memory content
+        content_summary, -- Memory summary
+        path,            -- Organization path
+        tags,            -- Concatenated tags for searching
+        domain,          -- Domain ID
+        tokenize="porter unicode61"  -- Use Porter stemming algorithm
+    );
+
+    -- Triggers to keep FTS index in sync with memory nodes
+    CREATE TRIGGER IF NOT EXISTS memory_nodes_ai AFTER INSERT ON MEMORY_NODES BEGIN
+        INSERT INTO memory_content_fts(id, content, content_summary, path, domain)
+        VALUES (new.id, new.content, new.content_summary, new.path, new.domain);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS memory_nodes_ad AFTER DELETE ON MEMORY_NODES BEGIN
+        DELETE FROM memory_content_fts WHERE id = old.id;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS memory_nodes_au AFTER UPDATE ON MEMORY_NODES BEGIN
+        DELETE FROM memory_content_fts WHERE id = old.id;
+        INSERT INTO memory_content_fts(id, content, content_summary, path, domain)
+        VALUES (new.id, new.content, new.content_summary, new.path, new.domain);
+    END;
+
+    -- Trigger to update tags in FTS when tags are added/removed
+    CREATE TRIGGER IF NOT EXISTS memory_tags_ai AFTER INSERT ON MEMORY_TAGS BEGIN
+        UPDATE memory_content_fts 
+        SET tags = (SELECT group_concat(tag, ' ') FROM MEMORY_TAGS WHERE nodeId = new.nodeId)
+        WHERE id = new.nodeId;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS memory_tags_ad AFTER DELETE ON MEMORY_TAGS BEGIN
+        UPDATE memory_content_fts 
+        SET tags = (SELECT group_concat(tag, ' ') FROM MEMORY_TAGS WHERE nodeId = old.nodeId)
+        WHERE id = old.nodeId;
+    END;
+  `);
+
+  console.log('Schema created successfully');
+}
+
+/**
+ * Create a sample domain
+ * @param {object} db - SQLite database connection
+ * @returns {string} - The created domain ID
+ */
+async function createSampleDomain(db) {
+  const now = new Date().toISOString();
+  const domainId = uuidv4();
+  
+  await db.run(
+    'INSERT INTO DOMAINS (id, name, description, created, lastAccess) VALUES (?, ?, ?, ?, ?)',
+    [domainId, 'Sample Domain', 'A sample domain for testing', now, now]
+  );
+  
+  // Set as current domain in persistence state
+  const persistenceExists = await db.get('SELECT 1 FROM PERSISTENCE WHERE id = 1');
+  
+  if (persistenceExists) {
+    await db.run(
+      'UPDATE PERSISTENCE SET currentDomain = ?, lastAccess = ? WHERE id = 1',
+      [domainId, now]
+    );
+  } else {
+    await db.run(
+      'INSERT INTO PERSISTENCE (id, currentDomain, lastAccess) VALUES (1, ?, ?)',
+      [domainId, now]
+    );
+  }
+  
+  console.log(`Created domain: ${domainId}`);
+  return domainId;
+}
+
+/**
+ * Add sample memories with relationships
+ * @param {object} db - SQLite database connection
+ * @param {string} domainId - Domain ID
+ */
+async function addSampleMemories(db, domainId) {
+  const now = new Date().toISOString();
+  
+  // Create first memory node
+  const node1Id = uuidv4();
+  await db.run(
+    'INSERT INTO MEMORY_NODES (id, domain, content, timestamp, path, content_summary) VALUES (?, ?, ?, ?, ?, ?)',
+    [
+      node1Id,
+      domainId,
+      'This is the first memory node with important information about the project.',
+      now,
+      '/projects',
+      'First memory with project info'
+    ]
+  );
+  
+  // Add tags to first node
+  await db.run('INSERT INTO MEMORY_TAGS (nodeId, tag) VALUES (?, ?)', [node1Id, 'project']);
+  await db.run('INSERT INTO MEMORY_TAGS (nodeId, tag) VALUES (?, ?)', [node1Id, 'important']);
+  
+  // Create second memory node
+  const node2Id = uuidv4();
+  await db.run(
+    'INSERT INTO MEMORY_NODES (id, domain, content, timestamp, path) VALUES (?, ?, ?, ?, ?)',
+    [
+      node2Id,
+      domainId,
+      'This is the second memory node with related details to the first node.',
+      now,
+      '/projects/details'
+    ]
+  );
+  
+  // Add tags to second node
+  await db.run('INSERT INTO MEMORY_TAGS (nodeId, tag) VALUES (?, ?)', [node2Id, 'details']);
+  
+  // Create edge between nodes
+  const edgeId = `${node1Id}-${node2Id}-related_to`;
+  await db.run(
+    'INSERT INTO MEMORY_EDGES (id, source, target, type, strength, timestamp, domain) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    [edgeId, node1Id, node2Id, 'related_to', 0.8, now, domainId]
+  );
+  
+  // Update persistence with latest memory
+  await db.run(
+    'UPDATE PERSISTENCE SET lastMemoryId = ? WHERE id = 1',
+    [node2Id]
+  );
+  
+  console.log(`Added sample memories: ${node1Id}, ${node2Id} with relationship`);
+}
+
+/**
+ * Perform a sample full-text search
+ * @param {object} db - SQLite database connection
+ * @param {string} query - Search query
+ */
+async function performSearch(db, query) {
+  console.log(`Searching for: "${query}"`);
+  
+  const rows = await db.all(`
+    SELECT m.* FROM MEMORY_NODES m
+    JOIN memory_content_fts fts ON m.id = fts.id
+    WHERE memory_content_fts MATCH ?
+    LIMIT 10
+  `, [query]);
+  
+  console.log(`Found ${rows.length} results:`);
+  
+  for (const row of rows) {
+    // Get tags for this node
+    const tagRows = await db.all('SELECT tag FROM MEMORY_TAGS WHERE nodeId = ?', [row.id]);
+    const tags = tagRows.map(t => t.tag);
+    
+    console.log(`- ID: ${row.id}`);
+    console.log(`  Content: ${row.content.substring(0, 50)}${row.content.length > 50 ? '...' : ''}`);
+    console.log(`  Path: ${row.path}`);
+    console.log(`  Tags: ${tags.join(', ')}`);
+    console.log(`  Summary: ${row.content_summary || 'N/A'}`);
+    console.log('-----------------------------');
+  }
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  console.log(`Creating database at: ${DB_PATH}`);
+  
+  try {
+    // Open database connection
+    const db = await open({
+      filename: DB_PATH,
+      driver: sqlite3.Database
+    });
+    
+    // Initialize schema
+    await initializeSchema(db);
+    
+    // Create sample data
+    const domainId = await createSampleDomain(db);
+    await addSampleMemories(db, domainId);
+    
+    // Perform a sample search
+    await performSearch(db, 'project');
+    
+    console.log('Database setup complete!');
+    console.log(`Database file: ${DB_PATH}`);
+    
+    // Close database connection
+    await db.close();
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
+
+// Run the script
+main().catch(console.error);

--- a/scripts/create-sqlite-db.ts
+++ b/scripts/create-sqlite-db.ts
@@ -1,0 +1,325 @@
+/**
+ * Example script to create and initialize a Memory Graph SQLite database
+ * This can be used independently of the main MCP server
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import sqlite3 from 'sqlite3';
+import { open, Database } from 'sqlite';
+import { v4 as uuidv4 } from 'uuid';
+
+// Database file path
+const DB_PATH = path.join(process.cwd(), 'memory-graph-example.db');
+
+/**
+ * Initialize the database schema
+ * @param db SQLite database connection
+ */
+async function initializeSchema(db: Database): Promise<void> {
+  console.log('Creating schema...');
+  
+  // Create tables and indexes
+  await db.exec(`
+    -- Enable foreign keys
+    PRAGMA foreign_keys = ON;
+
+    -- Create tables
+    -- Domains table
+    CREATE TABLE IF NOT EXISTS DOMAINS (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT,
+        created TEXT NOT NULL,
+        lastAccess TEXT NOT NULL
+    );
+
+    -- Persistence state table (single row)
+    CREATE TABLE IF NOT EXISTS PERSISTENCE (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        currentDomain TEXT NOT NULL,
+        lastAccess TEXT NOT NULL,
+        lastMemoryId TEXT,
+        FOREIGN KEY (currentDomain) REFERENCES DOMAINS(id)
+    );
+
+    -- Memory nodes table
+    CREATE TABLE IF NOT EXISTS MEMORY_NODES (
+        id TEXT PRIMARY KEY,
+        domain TEXT NOT NULL,
+        content TEXT NOT NULL,
+        timestamp TEXT NOT NULL,
+        path TEXT DEFAULT '/',
+        content_summary TEXT,
+        summary_timestamp TEXT,
+        FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+    );
+
+    -- Memory tags table (many-to-many)
+    CREATE TABLE IF NOT EXISTS MEMORY_TAGS (
+        nodeId TEXT NOT NULL,
+        tag TEXT NOT NULL,
+        PRIMARY KEY (nodeId, tag),
+        FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE
+    );
+
+    -- Memory edges table
+    CREATE TABLE IF NOT EXISTS MEMORY_EDGES (
+        id TEXT PRIMARY KEY,
+        source TEXT NOT NULL,
+        target TEXT NOT NULL,
+        type TEXT NOT NULL,
+        strength REAL NOT NULL CHECK (strength >= 0 AND strength <= 1),
+        timestamp TEXT NOT NULL,
+        domain TEXT NOT NULL,
+        FOREIGN KEY (source) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+        FOREIGN KEY (target) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+        FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+    );
+
+    -- Domain references table
+    CREATE TABLE IF NOT EXISTS DOMAIN_REFS (
+        nodeId TEXT NOT NULL,
+        domain TEXT NOT NULL,
+        targetDomain TEXT NOT NULL,
+        targetNodeId TEXT NOT NULL,
+        description TEXT,
+        bidirectional INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (nodeId, targetDomain, targetNodeId),
+        FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+        FOREIGN KEY (domain) REFERENCES DOMAINS(id),
+        FOREIGN KEY (targetDomain) REFERENCES DOMAINS(id)
+    );
+
+    -- Create indexes
+    -- For fast domain-based filtering
+    CREATE INDEX IF NOT EXISTS idx_memory_nodes_domain ON MEMORY_NODES(domain);
+
+    -- For fast tag lookups
+    CREATE INDEX IF NOT EXISTS idx_memory_tags_tag ON MEMORY_TAGS(tag);
+
+    -- For fast edge traversal
+    CREATE INDEX IF NOT EXISTS idx_memory_edges_source ON MEMORY_EDGES(source, domain);
+    CREATE INDEX IF NOT EXISTS idx_memory_edges_target ON MEMORY_EDGES(target, domain);
+
+    -- For fast domain reference lookups
+    CREATE INDEX IF NOT EXISTS idx_domain_refs_target ON DOMAIN_REFS(targetDomain, targetNodeId);
+  `);
+
+  // Create FTS5 table and triggers
+  await db.exec(`
+    -- Enable FTS5 extension for full-text search
+    CREATE VIRTUAL TABLE IF NOT EXISTS memory_content_fts USING fts5(
+        id,              -- Memory ID
+        content,         -- Memory content
+        content_summary, -- Memory summary
+        path,            -- Organization path
+        tags,            -- Concatenated tags for searching
+        domain,          -- Domain ID
+        tokenize="porter unicode61"  -- Use Porter stemming algorithm
+    );
+
+    -- Triggers to keep FTS index in sync with memory nodes
+    CREATE TRIGGER IF NOT EXISTS memory_nodes_ai AFTER INSERT ON MEMORY_NODES BEGIN
+        INSERT INTO memory_content_fts(id, content, content_summary, path, domain)
+        VALUES (new.id, new.content, new.content_summary, new.path, new.domain);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS memory_nodes_ad AFTER DELETE ON MEMORY_NODES BEGIN
+        DELETE FROM memory_content_fts WHERE id = old.id;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS memory_nodes_au AFTER UPDATE ON MEMORY_NODES BEGIN
+        DELETE FROM memory_content_fts WHERE id = old.id;
+        INSERT INTO memory_content_fts(id, content, content_summary, path, domain)
+        VALUES (new.id, new.content, new.content_summary, new.path, new.domain);
+    END;
+
+    -- Trigger to update tags in FTS when tags are added/removed
+    CREATE TRIGGER IF NOT EXISTS memory_tags_ai AFTER INSERT ON MEMORY_TAGS BEGIN
+        UPDATE memory_content_fts 
+        SET tags = (SELECT group_concat(tag, ' ') FROM MEMORY_TAGS WHERE nodeId = new.nodeId)
+        WHERE id = new.nodeId;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS memory_tags_ad AFTER DELETE ON MEMORY_TAGS BEGIN
+        UPDATE memory_content_fts 
+        SET tags = (SELECT group_concat(tag, ' ') FROM MEMORY_TAGS WHERE nodeId = old.nodeId)
+        WHERE id = old.nodeId;
+    END;
+  `);
+
+  console.log('Schema created successfully');
+}
+
+/**
+ * Create a sample domain
+ * @param db SQLite database connection
+ * @returns The created domain ID
+ */
+async function createSampleDomain(db: Database): Promise<string> {
+  const now = new Date().toISOString();
+  const domainId = uuidv4();
+  
+  await db.run(
+    'INSERT INTO DOMAINS (id, name, description, created, lastAccess) VALUES (?, ?, ?, ?, ?)',
+    [domainId, 'Sample Domain', 'A sample domain for testing', now, now]
+  );
+  
+  // Set as current domain in persistence state
+  const persistenceExists = await db.get('SELECT 1 FROM PERSISTENCE WHERE id = 1');
+  
+  if (persistenceExists) {
+    await db.run(
+      'UPDATE PERSISTENCE SET currentDomain = ?, lastAccess = ? WHERE id = 1',
+      [domainId, now]
+    );
+  } else {
+    await db.run(
+      'INSERT INTO PERSISTENCE (id, currentDomain, lastAccess) VALUES (1, ?, ?)',
+      [domainId, now]
+    );
+  }
+  
+  console.log(`Created domain: ${domainId}`);
+  return domainId;
+}
+
+/**
+ * Add sample memories with relationships
+ * @param db SQLite database connection
+ * @param domainId Domain ID
+ */
+async function addSampleMemories(db: Database, domainId: string): Promise<void> {
+  const now = new Date().toISOString();
+  
+  // Create first memory node
+  const node1Id = uuidv4();
+  await db.run(
+    'INSERT INTO MEMORY_NODES (id, domain, content, timestamp, path, content_summary) VALUES (?, ?, ?, ?, ?, ?)',
+    [
+      node1Id,
+      domainId,
+      'This is the first memory node with important information about the project.',
+      now,
+      '/projects',
+      'First memory with project info'
+    ]
+  );
+  
+  // Add tags to first node
+  await db.run('INSERT INTO MEMORY_TAGS (nodeId, tag) VALUES (?, ?)', [node1Id, 'project']);
+  await db.run('INSERT INTO MEMORY_TAGS (nodeId, tag) VALUES (?, ?)', [node1Id, 'important']);
+  
+  // Create second memory node
+  const node2Id = uuidv4();
+  await db.run(
+    'INSERT INTO MEMORY_NODES (id, domain, content, timestamp, path) VALUES (?, ?, ?, ?, ?)',
+    [
+      node2Id,
+      domainId,
+      'This is the second memory node with related details to the first node.',
+      now,
+      '/projects/details'
+    ]
+  );
+  
+  // Add tags to second node
+  await db.run('INSERT INTO MEMORY_TAGS (nodeId, tag) VALUES (?, ?)', [node2Id, 'details']);
+  
+  // Create edge between nodes
+  const edgeId = `${node1Id}-${node2Id}-related_to`;
+  await db.run(
+    'INSERT INTO MEMORY_EDGES (id, source, target, type, strength, timestamp, domain) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    [edgeId, node1Id, node2Id, 'related_to', 0.8, now, domainId]
+  );
+  
+  // Update persistence with latest memory
+  await db.run(
+    'UPDATE PERSISTENCE SET lastMemoryId = ? WHERE id = 1',
+    [node2Id]
+  );
+  
+  console.log(`Added sample memories: ${node1Id}, ${node2Id} with relationship`);
+}
+
+interface TagRow {
+  tag: string;
+}
+
+interface MemoryRow {
+  id: string;
+  content: string;
+  timestamp: string;
+  path: string;
+  content_summary: string | null;
+  summary_timestamp: string | null;
+  domain: string;
+}
+
+/**
+ * Perform a sample full-text search
+ * @param db SQLite database connection
+ * @param query Search query
+ */
+async function performSearch(db: Database, query: string): Promise<void> {
+  console.log(`Searching for: "${query}"`);
+  
+  const rows = await db.all<MemoryRow[]>(`
+    SELECT m.* FROM MEMORY_NODES m
+    JOIN memory_content_fts fts ON m.id = fts.id
+    WHERE memory_content_fts MATCH ?
+    LIMIT 10
+  `, [query]);
+  
+  console.log(`Found ${rows.length} results:`);
+  
+  for (const row of rows) {
+    // Get tags for this node
+    const tagRows = await db.all<TagRow[]>('SELECT tag FROM MEMORY_TAGS WHERE nodeId = ?', [row.id]);
+    const tags = tagRows.map(t => t.tag);
+    
+    console.log(`- ID: ${row.id}`);
+    console.log(`  Content: ${row.content.substring(0, 50)}${row.content.length > 50 ? '...' : ''}`);
+    console.log(`  Path: ${row.path}`);
+    console.log(`  Tags: ${tags.join(', ')}`);
+    console.log(`  Summary: ${row.content_summary || 'N/A'}`);
+    console.log('-----------------------------');
+  }
+}
+
+/**
+ * Main function
+ */
+async function main(): Promise<void> {
+  console.log(`Creating database at: ${DB_PATH}`);
+  
+  try {
+    // Open database connection
+    const db = await open({
+      filename: DB_PATH,
+      driver: sqlite3.Database
+    });
+    
+    // Initialize schema
+    await initializeSchema(db);
+    
+    // Create sample data
+    const domainId = await createSampleDomain(db);
+    await addSampleMemories(db, domainId);
+    
+    // Perform a sample search
+    await performSearch(db, 'project');
+    
+    console.log('Database setup complete!');
+    console.log(`Database file: ${DB_PATH}`);
+    
+    // Close database connection
+    await db.close();
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
+
+// Run the script
+main().catch(console.error);

--- a/src/graph/MemoryGraph.ts
+++ b/src/graph/MemoryGraph.ts
@@ -33,11 +33,18 @@ export class MemoryGraph {
     this.currentDomain = config.defaultDomain || 'general';
     
     // Initialize storage based on config
-    const storageType = (config.storageType?.toLowerCase() === 'sqlite') 
-      ? StorageType.SQLITE 
-      : StorageType.JSON;
+    let storageType = StorageType.JSON;
     
-    this.storage = StorageFactory.createStorage(storageType, config.storageDir);
+    if (config.storageType) {
+      const typeValue = config.storageType.toLowerCase();
+      if (typeValue === 'sqlite') {
+        storageType = StorageType.SQLITE;
+      } else if (typeValue === 'mariadb') {
+        storageType = StorageType.MARIADB;
+      }
+    }
+    
+    this.storage = StorageFactory.createStorage(storageType, config.storageDir, config.dbConfig);
   }
 
   private generateId(): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,10 +46,24 @@ class MemoryGraphServer {
       console.log(`STORAGE_TYPE: ${storageType}`);
     }
 
+    // Configure MariaDB options if needed
+    const dbConfig = storageType.toLowerCase() === 'mariadb' ? {
+      host: process.env.MARIADB_HOST || 'localhost',
+      user: process.env.MARIADB_USER || 'root',
+      password: process.env.MARIADB_PASSWORD || '',
+      database: process.env.MARIADB_DATABASE || 'memory_graph',
+      port: process.env.MARIADB_PORT ? parseInt(process.env.MARIADB_PORT, 10) : 3306,
+      waitForConnections: true,
+      connectionLimit: process.env.MARIADB_CONNECTION_LIMIT ? 
+        parseInt(process.env.MARIADB_CONNECTION_LIMIT, 10) : 10,
+      queueLimit: 0
+    } : undefined;
+
     this.memoryGraph = new MemoryGraph({
       storageDir,
       defaultPath: process.env.DEFAULT_PATH || '/',
       storageType: storageType,
+      dbConfig
     });
     this.memoryTools = new MemoryTools(this.memoryGraph);
     this.memoryResources = new MemoryResources(this.memoryGraph);

--- a/src/storage/DatabaseStorage.ts
+++ b/src/storage/DatabaseStorage.ts
@@ -1,0 +1,307 @@
+import { DomainInfo, GraphEdge, MemoryNode, PersistenceState } from '../types/graph.js';
+import { MemoryStorage } from './MemoryStorage.js';
+
+/**
+ * Abstract base class for SQL-based storage implementations.
+ * This provides common functionality for both SQLite and MariaDB implementations.
+ */
+export abstract class DatabaseStorage implements MemoryStorage {
+  protected abstract getConnection(): Promise<any>;
+  
+  /**
+   * Initialize the storage
+   * Creates necessary tables, indexes, and triggers
+   */
+  abstract initialize(): Promise<void>;
+  
+  /**
+   * Get all domains
+   * @returns Map of domain IDs to domain info
+   */
+  async getDomains(): Promise<Map<string, DomainInfo>> {
+    const conn = await this.getConnection();
+    const rows = await this.executeQuery(conn, 'SELECT * FROM DOMAINS');
+    
+    const domains = new Map<string, DomainInfo>();
+    for (const row of rows) {
+      domains.set(row.id, {
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        created: row.created,
+        lastAccess: row.lastAccess
+      });
+    }
+    
+    return domains;
+  }
+  
+  /**
+   * Save domains
+   * @param domains Map of domain IDs to domain info
+   */
+  async saveDomains(domains: Map<string, DomainInfo>): Promise<void> {
+    const conn = await this.getConnection();
+    
+    // Start a transaction
+    await this.beginTransaction(conn);
+    
+    try {
+      // Clear existing domains
+      await this.executeUpdate(conn, 'DELETE FROM DOMAINS');
+      
+      // Insert new domains
+      for (const domain of domains.values()) {
+        await this.executeUpdate(
+          conn,
+          'INSERT INTO DOMAINS (id, name, description, created, lastAccess) VALUES (?, ?, ?, ?, ?)',
+          [domain.id, domain.name, domain.description, domain.created, domain.lastAccess]
+        );
+      }
+      
+      // Commit the transaction
+      await this.commitTransaction(conn);
+    } catch (error) {
+      // Rollback on error
+      await this.rollbackTransaction(conn);
+      throw error;
+    }
+  }
+  
+  /**
+   * Create a new domain
+   * @param domain Domain info
+   */
+  async createDomain(domain: DomainInfo): Promise<void> {
+    const conn = await this.getConnection();
+    
+    await this.executeUpdate(
+      conn,
+      'INSERT INTO DOMAINS (id, name, description, created, lastAccess) VALUES (?, ?, ?, ?, ?)',
+      [domain.id, domain.name, domain.description, domain.created, domain.lastAccess]
+    );
+  }
+  
+  /**
+   * Get persistence state
+   * @returns Persistence state
+   */
+  async getPersistenceState(): Promise<PersistenceState> {
+    const conn = await this.getConnection();
+    const row = await this.executeQuerySingle(conn, 'SELECT * FROM PERSISTENCE WHERE id = 1');
+    
+    if (!row) {
+      throw new Error('Persistence state not found');
+    }
+    
+    return {
+      currentDomain: row.currentDomain,
+      lastAccess: row.lastAccess,
+      lastMemoryId: row.lastMemoryId
+    };
+  }
+  
+  /**
+   * Save persistence state
+   * @param state Persistence state
+   */
+  async savePersistenceState(state: PersistenceState): Promise<void> {
+    const conn = await this.getConnection();
+    
+    // Check if persistence state exists
+    const exists = await this.executeQuerySingle(conn, 'SELECT 1 FROM PERSISTENCE WHERE id = 1');
+    
+    if (exists) {
+      // Update existing state
+      await this.executeUpdate(
+        conn,
+        'UPDATE PERSISTENCE SET currentDomain = ?, lastAccess = ?, lastMemoryId = ? WHERE id = 1',
+        [state.currentDomain, state.lastAccess, state.lastMemoryId]
+      );
+    } else {
+      // Insert new state
+      await this.executeUpdate(
+        conn,
+        'INSERT INTO PERSISTENCE (id, currentDomain, lastAccess, lastMemoryId) VALUES (1, ?, ?, ?)',
+        [state.currentDomain, state.lastAccess, state.lastMemoryId]
+      );
+    }
+  }
+  
+  /**
+   * Get memories for a domain
+   * @param domain Domain ID
+   * @returns Object containing nodes and edges
+   */
+  async getMemories(domain: string): Promise<{ nodes: Map<string, MemoryNode>, edges: GraphEdge[] }> {
+    const conn = await this.getConnection();
+    
+    // Get nodes
+    const nodeRows = await this.executeQuery(conn, 'SELECT * FROM MEMORY_NODES WHERE domain = ?', [domain]);
+    const nodes = new Map<string, MemoryNode>();
+    
+    for (const row of nodeRows) {
+      // Get tags for this node
+      const tagRows = await this.executeQuery(conn, 'SELECT tag FROM MEMORY_TAGS WHERE nodeId = ?', [row.id]);
+      const tags = tagRows.map((t: { tag: string }) => t.tag);
+      
+      // Get domain refs for this node
+      const refRows = await this.executeQuery(conn, 'SELECT * FROM DOMAIN_REFS WHERE nodeId = ?', [row.id]);
+      const domainRefs = refRows.map((ref: any) => ({
+        domain: ref.targetDomain,
+        nodeId: ref.targetNodeId,
+        description: ref.description,
+        bidirectional: this.getBooleanValue(ref.bidirectional)
+      }));
+      
+      nodes.set(row.id, {
+        id: row.id,
+        content: row.content,
+        timestamp: row.timestamp,
+        path: row.path,
+        tags: tags.length > 0 ? tags : undefined,
+        domainRefs: domainRefs.length > 0 ? domainRefs : undefined,
+        content_summary: row.content_summary,
+        summary_timestamp: row.summary_timestamp
+      });
+    }
+    
+    // Get edges
+    const edgeRows = await this.executeQuery(conn, 'SELECT * FROM MEMORY_EDGES WHERE domain = ?', [domain]);
+    const edges = edgeRows.map((row: any) => ({
+      source: row.source,
+      target: row.target,
+      type: row.type,
+      strength: row.strength,
+      timestamp: row.timestamp
+    }));
+    
+    return { nodes, edges };
+  }
+  
+  /**
+   * Save memories for a domain
+   * @param domain Domain ID
+   * @param nodes Map of node IDs to nodes
+   * @param edges Array of edges
+   */
+  async saveMemories(domain: string, nodes: Map<string, MemoryNode>, edges: GraphEdge[]): Promise<void> {
+    const conn = await this.getConnection();
+    
+    // Start a transaction
+    await this.beginTransaction(conn);
+    
+    try {
+      // Clear existing data for this domain
+      await this.executeUpdate(conn, 'DELETE FROM MEMORY_NODES WHERE domain = ?', [domain]);
+      await this.executeUpdate(conn, 'DELETE FROM MEMORY_EDGES WHERE domain = ?', [domain]);
+      
+      // Insert nodes
+      for (const node of nodes.values()) {
+        await this.executeUpdate(
+          conn,
+          'INSERT INTO MEMORY_NODES (id, domain, content, timestamp, path, content_summary, summary_timestamp) VALUES (?, ?, ?, ?, ?, ?, ?)',
+          [node.id, domain, node.content, node.timestamp, node.path || '/', node.content_summary, node.summary_timestamp]
+        );
+        
+        // Insert tags
+        if (node.tags && node.tags.length > 0) {
+          for (const tag of node.tags) {
+            await this.executeUpdate(
+              conn,
+              this.getInsertIgnoreStatement('MEMORY_TAGS', '(nodeId, tag) VALUES (?, ?)'),
+              [node.id, tag]
+            );
+          }
+        }
+        
+        // Insert domain refs
+        if (node.domainRefs && node.domainRefs.length > 0) {
+          for (const ref of node.domainRefs) {
+            await this.executeUpdate(
+              conn,
+              this.getInsertIgnoreStatement('DOMAIN_REFS', '(nodeId, domain, targetDomain, targetNodeId, description, bidirectional) VALUES (?, ?, ?, ?, ?, ?)'),
+              [node.id, domain, ref.domain, ref.nodeId, ref.description || null, this.setBooleanValue(ref.bidirectional)]
+            );
+          }
+        }
+      }
+      
+      // Insert edges
+      for (const edge of edges) {
+        const edgeId = `${edge.source}-${edge.target}-${edge.type}`;
+        await this.executeUpdate(
+          conn,
+          this.getInsertReplaceStatement('MEMORY_EDGES', '(id, source, target, type, strength, timestamp, domain) VALUES (?, ?, ?, ?, ?, ?, ?)'),
+          [edgeId, edge.source, edge.target, edge.type, edge.strength, edge.timestamp, domain]
+        );
+      }
+      
+      // Commit the transaction
+      await this.commitTransaction(conn);
+    } catch (error) {
+      // Rollback on error
+      await this.rollbackTransaction(conn);
+      throw error;
+    }
+  }
+  
+  /**
+   * Search memory content using full-text search
+   * @param query Search query
+   * @param domain Optional domain to restrict search to
+   * @param maxResults Maximum number of results to return
+   * @returns Array of matching memory nodes
+   */
+  abstract searchContent(query: string, domain?: string, maxResults?: number): Promise<MemoryNode[]>;
+  
+  /**
+   * Execute a query that returns multiple rows
+   */
+  protected abstract executeQuery(connection: any, sql: string, params?: any[]): Promise<any[]>;
+  
+  /**
+   * Execute a query that returns a single row
+   */
+  protected abstract executeQuerySingle(connection: any, sql: string, params?: any[]): Promise<any>;
+  
+  /**
+   * Execute an update statement
+   */
+  protected abstract executeUpdate(connection: any, sql: string, params?: any[]): Promise<any>;
+  
+  /**
+   * Begin a database transaction
+   */
+  protected abstract beginTransaction(connection: any): Promise<void>;
+  
+  /**
+   * Commit a database transaction
+   */
+  protected abstract commitTransaction(connection: any): Promise<void>;
+  
+  /**
+   * Rollback a database transaction
+   */
+  protected abstract rollbackTransaction(connection: any): Promise<void>;
+  
+  /**
+   * Get the appropriate INSERT IGNORE statement for the database
+   */
+  protected abstract getInsertIgnoreStatement(table: string, valuesClause: string): string;
+  
+  /**
+   * Get the appropriate INSERT REPLACE statement for the database
+   */
+  protected abstract getInsertReplaceStatement(table: string, valuesClause: string): string;
+  
+  /**
+   * Convert a database boolean value to a JavaScript boolean
+   */
+  protected abstract getBooleanValue(value: any): boolean;
+  
+  /**
+   * Convert a JavaScript boolean to a database value
+   */
+  protected abstract setBooleanValue(value?: boolean): any;
+}

--- a/src/storage/MariaDbMemoryStorage.ts
+++ b/src/storage/MariaDbMemoryStorage.ts
@@ -1,0 +1,368 @@
+import path from 'path';
+import mysql from 'mysql2/promise';
+import { MemoryNode } from '../types/graph.js';
+import { DatabaseStorage } from './DatabaseStorage.js';
+
+/**
+ * MariaDB implementation of MemoryStorage
+ */
+export class MariaDbMemoryStorage extends DatabaseStorage {
+  private pool: mysql.Pool | null = null;
+  private config: mysql.PoolOptions;
+
+  /**
+   * Constructor
+   * @param storageDir Storage directory - ignored for MariaDB, used for config consistency
+   * @param dbConfig MariaDB connection configuration
+   */
+  constructor(storageDir: string, dbConfig?: mysql.PoolOptions) {
+    super();
+    
+    // Default configuration
+    this.config = dbConfig || {
+      host: process.env.MARIADB_HOST || 'localhost',
+      user: process.env.MARIADB_USER || 'root',
+      password: process.env.MARIADB_PASSWORD || '',
+      database: process.env.MARIADB_DATABASE || 'memory_graph',
+      waitForConnections: true,
+      connectionLimit: 10,
+      queueLimit: 0
+    };
+  }
+
+  /**
+   * Get database connection
+   * @returns Database connection
+   */
+  protected async getConnection(): Promise<mysql.PoolConnection> {
+    if (!this.pool) {
+      this.pool = mysql.createPool(this.config);
+    }
+    return this.pool.getConnection();
+  }
+
+  /**
+   * Initialize the storage
+   * Creates necessary tables, indexes, and functions
+   */
+  async initialize(): Promise<void> {
+    // Create the database if it doesn't exist
+    await this.createDatabaseIfNeeded();
+    
+    const conn = await this.getConnection();
+    
+    try {
+      // Enable foreign keys
+      await conn.execute('SET FOREIGN_KEY_CHECKS=1');
+      
+      // Create tables
+      await conn.execute(`
+        -- Domains table
+        CREATE TABLE IF NOT EXISTS DOMAINS (
+            id VARCHAR(36) PRIMARY KEY,
+            name VARCHAR(255) NOT NULL,
+            description TEXT,
+            created VARCHAR(30) NOT NULL,
+            lastAccess VARCHAR(30) NOT NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+        -- Persistence state table (single row)
+        CREATE TABLE IF NOT EXISTS PERSISTENCE (
+            id INT PRIMARY KEY CHECK (id = 1),
+            currentDomain VARCHAR(36) NOT NULL,
+            lastAccess VARCHAR(30) NOT NULL,
+            lastMemoryId VARCHAR(36),
+            FOREIGN KEY (currentDomain) REFERENCES DOMAINS(id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+        -- Memory nodes table
+        CREATE TABLE IF NOT EXISTS MEMORY_NODES (
+            id VARCHAR(36) PRIMARY KEY,
+            domain VARCHAR(36) NOT NULL,
+            content TEXT NOT NULL,
+            timestamp VARCHAR(30) NOT NULL,
+            path VARCHAR(255) DEFAULT '/',
+            content_summary TEXT,
+            summary_timestamp VARCHAR(30),
+            FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+        -- Memory tags table (many-to-many)
+        CREATE TABLE IF NOT EXISTS MEMORY_TAGS (
+            nodeId VARCHAR(36) NOT NULL,
+            tag VARCHAR(255) NOT NULL,
+            PRIMARY KEY (nodeId, tag),
+            FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+        -- Memory edges table
+        CREATE TABLE IF NOT EXISTS MEMORY_EDGES (
+            id VARCHAR(255) PRIMARY KEY,
+            source VARCHAR(36) NOT NULL,
+            target VARCHAR(36) NOT NULL,
+            type VARCHAR(255) NOT NULL,
+            strength DECIMAL(3,2) NOT NULL CHECK (strength >= 0 AND strength <= 1),
+            timestamp VARCHAR(30) NOT NULL,
+            domain VARCHAR(36) NOT NULL,
+            FOREIGN KEY (source) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+            FOREIGN KEY (target) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+            FOREIGN KEY (domain) REFERENCES DOMAINS(id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+        -- Domain references table
+        CREATE TABLE IF NOT EXISTS DOMAIN_REFS (
+            nodeId VARCHAR(36) NOT NULL,
+            domain VARCHAR(36) NOT NULL,
+            targetDomain VARCHAR(36) NOT NULL,
+            targetNodeId VARCHAR(36) NOT NULL,
+            description TEXT,
+            bidirectional BOOLEAN NOT NULL DEFAULT 0,
+            PRIMARY KEY (nodeId, targetDomain, targetNodeId),
+            FOREIGN KEY (nodeId) REFERENCES MEMORY_NODES(id) ON DELETE CASCADE,
+            FOREIGN KEY (domain) REFERENCES DOMAINS(id),
+            FOREIGN KEY (targetDomain) REFERENCES DOMAINS(id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+      `);
+
+      // Create indexes
+      await conn.execute(`
+        -- For fast domain-based filtering
+        CREATE INDEX IF NOT EXISTS idx_memory_nodes_domain ON MEMORY_NODES(domain);
+
+        -- For fast tag lookups
+        CREATE INDEX IF NOT EXISTS idx_memory_tags_tag ON MEMORY_TAGS(tag);
+
+        -- For fast edge traversal
+        CREATE INDEX IF NOT EXISTS idx_memory_edges_source ON MEMORY_EDGES(source, domain);
+        CREATE INDEX IF NOT EXISTS idx_memory_edges_target ON MEMORY_EDGES(target, domain);
+
+        -- For fast domain reference lookups
+        CREATE INDEX IF NOT EXISTS idx_domain_refs_target ON DOMAIN_REFS(targetDomain, targetNodeId);
+      `);
+
+      // Full-text search indexes
+      await conn.execute(`
+        -- Add FULLTEXT index on content and summary
+        ALTER TABLE MEMORY_NODES ADD FULLTEXT INDEX IF NOT EXISTS ft_memory_content (content, content_summary);
+      `);
+
+      // Create the tag concatenation function
+      await this.createTagConcatFunction(conn);
+      
+      // Create view for combined search
+      await conn.execute(`
+        -- Create a view that combines memory node content with tags for full-text searching
+        CREATE OR REPLACE VIEW memory_content_search AS
+        SELECT 
+            m.id,
+            m.content,
+            m.content_summary,
+            m.path,
+            m.domain,
+            get_node_tags(m.id) AS tags
+        FROM MEMORY_NODES m;
+      `);
+    } finally {
+      conn.release();
+    }
+  }
+
+  /**
+   * Create the database if it doesn't exist
+   */
+  private async createDatabaseIfNeeded(): Promise<void> {
+    const tempConfig = { ...this.config };
+    delete tempConfig.database;
+    
+    const tempPool = mysql.createPool(tempConfig);
+    let tempConn;
+    
+    try {
+      tempConn = await tempPool.getConnection();
+      await tempConn.execute(
+        `CREATE DATABASE IF NOT EXISTS ${this.config.database} CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci`
+      );
+    } finally {
+      if (tempConn) tempConn.release();
+      await tempPool.end();
+    }
+  }
+
+  /**
+   * Create the tag concatenation function
+   */
+  private async createTagConcatFunction(conn: mysql.PoolConnection): Promise<void> {
+    // Check if function exists
+    const [rows] = await conn.execute(
+      'SELECT ROUTINE_NAME FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_SCHEMA = ? AND ROUTINE_NAME = ?',
+      [this.config.database, 'get_node_tags']
+    );
+    
+    // If function doesn't exist, create it
+    if (Array.isArray(rows) && rows.length === 0) {
+      await conn.execute(`
+        DROP FUNCTION IF EXISTS get_node_tags;
+        DELIMITER //
+        CREATE FUNCTION get_node_tags(node_id VARCHAR(36)) 
+        RETURNS TEXT
+        DETERMINISTIC
+        BEGIN
+          DECLARE result TEXT;
+          SELECT GROUP_CONCAT(tag SEPARATOR ' ') INTO result FROM MEMORY_TAGS WHERE nodeId = node_id;
+          RETURN result;
+        END//
+        DELIMITER ;
+      `);
+    }
+  }
+
+  /**
+   * Search memory content using MariaDB FULLTEXT search
+   * @param query Search query
+   * @param domain Optional domain to restrict search to
+   * @param maxResults Maximum number of results to return
+   * @returns Array of matching memory nodes
+   */
+  async searchContent(query: string, domain?: string, maxResults: number = 20): Promise<MemoryNode[]> {
+    const conn = await this.getConnection();
+    
+    try {
+      // Clean the query for use with MATCH AGAINST
+      const cleanQuery = query.replace(/[+\-><()~*"@]+/g, ' ').trim();
+      
+      let sql = `
+        SELECT m.* FROM MEMORY_NODES m
+        WHERE MATCH(m.content, m.content_summary) AGAINST(? IN NATURAL LANGUAGE MODE)
+      `;
+      
+      const params: any[] = [cleanQuery];
+      
+      if (domain) {
+        sql += ' AND m.domain = ?';
+        params.push(domain);
+      }
+      
+      sql += ' LIMIT ?';
+      params.push(maxResults);
+      
+      const [rows] = await conn.execute(sql, params);
+      const results: MemoryNode[] = [];
+      
+      if (Array.isArray(rows)) {
+        for (const row of rows as any[]) {
+          // Get tags for this node
+          const [tagRows] = await conn.execute('SELECT tag FROM MEMORY_TAGS WHERE nodeId = ?', [row.id]);
+          const tags = (tagRows as any[]).map(t => t.tag);
+          
+          // Get domain refs for this node
+          const [refRows] = await conn.execute('SELECT * FROM DOMAIN_REFS WHERE nodeId = ?', [row.id]);
+          const domainRefs = (refRows as any[]).map(ref => ({
+            domain: ref.targetDomain,
+            nodeId: ref.targetNodeId,
+            description: ref.description,
+            bidirectional: this.getBooleanValue(ref.bidirectional)
+          }));
+          
+          results.push({
+            id: row.id,
+            content: row.content,
+            timestamp: row.timestamp,
+            path: row.path,
+            tags: tags.length > 0 ? tags : undefined,
+            domainRefs: domainRefs.length > 0 ? domainRefs : undefined,
+            content_summary: row.content_summary,
+            summary_timestamp: row.summary_timestamp
+          });
+        }
+      }
+      
+      return results;
+    } finally {
+      conn.release();
+    }
+  }
+
+  /**
+   * Execute a query that returns multiple rows
+   */
+  protected async executeQuery(connection: mysql.PoolConnection, sql: string, params: any[] = []): Promise<any[]> {
+    const [rows] = await connection.execute(sql, params);
+    return rows as any[];
+  }
+
+  /**
+   * Execute a query that returns a single row
+   */
+  protected async executeQuerySingle(connection: mysql.PoolConnection, sql: string, params: any[] = []): Promise<any> {
+    const [rows] = await connection.execute(sql, params);
+    const rowsArray = rows as any[];
+    return rowsArray.length > 0 ? rowsArray[0] : null;
+  }
+
+  /**
+   * Execute an update statement
+   */
+  protected async executeUpdate(connection: mysql.PoolConnection, sql: string, params: any[] = []): Promise<any> {
+    const result = await connection.execute(sql, params);
+    return result;
+  }
+
+  /**
+   * Begin a database transaction
+   */
+  protected async beginTransaction(connection: mysql.PoolConnection): Promise<void> {
+    await connection.beginTransaction();
+  }
+
+  /**
+   * Commit a database transaction
+   */
+  protected async commitTransaction(connection: mysql.PoolConnection): Promise<void> {
+    await connection.commit();
+  }
+
+  /**
+   * Rollback a database transaction
+   */
+  protected async rollbackTransaction(connection: mysql.PoolConnection): Promise<void> {
+    await connection.rollback();
+  }
+
+  /**
+   * Get the appropriate INSERT IGNORE statement for MariaDB
+   */
+  protected getInsertIgnoreStatement(table: string, valuesClause: string): string {
+    return `INSERT IGNORE INTO ${table} ${valuesClause}`;
+  }
+
+  /**
+   * Get the appropriate INSERT REPLACE statement for MariaDB
+   */
+  protected getInsertReplaceStatement(table: string, valuesClause: string): string {
+    return `REPLACE INTO ${table} ${valuesClause}`;
+  }
+
+  /**
+   * Convert a MariaDB boolean value to a JavaScript boolean
+   */
+  protected getBooleanValue(value: any): boolean {
+    return !!value;
+  }
+
+  /**
+   * Convert a JavaScript boolean to a MariaDB value
+   */
+  protected setBooleanValue(value?: boolean): boolean {
+    return !!value;
+  }
+
+  /**
+   * Close the database connection pool
+   */
+  async close(): Promise<void> {
+    if (this.pool) {
+      await this.pool.end();
+      this.pool = null;
+    }
+  }
+}

--- a/src/storage/MemoryStorage.ts
+++ b/src/storage/MemoryStorage.ts
@@ -71,5 +71,6 @@ export interface MemoryStorage {
  */
 export enum StorageType {
   JSON = 'json',
-  SQLITE = 'sqlite'
+  SQLITE = 'sqlite',
+  MARIADB = 'mariadb'
 }

--- a/src/storage/SqliteMemoryStorage.ts
+++ b/src/storage/SqliteMemoryStorage.ts
@@ -1,14 +1,13 @@
-import { promises as fs } from 'fs';
 import path from 'path';
 import sqlite3 from 'sqlite3';
 import { open, Database } from 'sqlite';
-import { DomainInfo, GraphEdge, MemoryNode, PersistenceState } from '../types/graph.js';
-import { MemoryStorage } from './MemoryStorage.js';
+import { MemoryNode } from '../types/graph.js';
+import { DatabaseStorage } from './DatabaseStorage.js';
 
 /**
  * SQLite implementation of MemoryStorage
  */
-export class SqliteMemoryStorage implements MemoryStorage {
+export class SqliteMemoryStorage extends DatabaseStorage {
   private dbPath: string;
   private db: Database | null = null;
 
@@ -17,6 +16,7 @@ export class SqliteMemoryStorage implements MemoryStorage {
    * @param storageDir Storage directory
    */
   constructor(storageDir: string) {
+    super();
     this.dbPath = path.join(storageDir, 'memory-graph.db');
   }
 
@@ -24,7 +24,7 @@ export class SqliteMemoryStorage implements MemoryStorage {
    * Get database connection
    * @returns Database connection
    */
-  private async getDatabase(): Promise<Database> {
+  protected async getConnection(): Promise<Database> {
     if (!this.db) {
       this.db = await open({
         filename: this.dbPath,
@@ -39,7 +39,7 @@ export class SqliteMemoryStorage implements MemoryStorage {
    * Creates necessary tables, indexes, and triggers
    */
   async initialize(): Promise<void> {
-    const db = await this.getDatabase();
+    const db = await this.getConnection();
     
     // Create tables
     await db.exec(`
@@ -171,229 +171,6 @@ export class SqliteMemoryStorage implements MemoryStorage {
   }
 
   /**
-   * Get all domains
-   * @returns Map of domain IDs to domain info
-   */
-  async getDomains(): Promise<Map<string, DomainInfo>> {
-    const db = await this.getDatabase();
-    const rows = await db.all('SELECT * FROM DOMAINS');
-    
-    const domains = new Map<string, DomainInfo>();
-    for (const row of rows) {
-      domains.set(row.id, {
-        id: row.id,
-        name: row.name,
-        description: row.description,
-        created: row.created,
-        lastAccess: row.lastAccess
-      });
-    }
-    
-    return domains;
-  }
-
-  /**
-   * Save domains
-   * @param domains Map of domain IDs to domain info
-   */
-  async saveDomains(domains: Map<string, DomainInfo>): Promise<void> {
-    const db = await this.getDatabase();
-    
-    // Start a transaction
-    await db.run('BEGIN TRANSACTION');
-    
-    try {
-      // Clear existing domains
-      await db.run('DELETE FROM DOMAINS');
-      
-      // Insert new domains
-      for (const domain of domains.values()) {
-        await db.run(
-          'INSERT INTO DOMAINS (id, name, description, created, lastAccess) VALUES (?, ?, ?, ?, ?)',
-          [domain.id, domain.name, domain.description, domain.created, domain.lastAccess]
-        );
-      }
-      
-      // Commit the transaction
-      await db.run('COMMIT');
-    } catch (error) {
-      // Rollback on error
-      await db.run('ROLLBACK');
-      throw error;
-    }
-  }
-
-  /**
-   * Create a new domain
-   * @param domain Domain info
-   */
-  async createDomain(domain: DomainInfo): Promise<void> {
-    const db = await this.getDatabase();
-    
-    await db.run(
-      'INSERT INTO DOMAINS (id, name, description, created, lastAccess) VALUES (?, ?, ?, ?, ?)',
-      [domain.id, domain.name, domain.description, domain.created, domain.lastAccess]
-    );
-  }
-
-  /**
-   * Get persistence state
-   * @returns Persistence state
-   */
-  async getPersistenceState(): Promise<PersistenceState> {
-    const db = await this.getDatabase();
-    const row = await db.get('SELECT * FROM PERSISTENCE WHERE id = 1');
-    
-    if (!row) {
-      throw new Error('Persistence state not found');
-    }
-    
-    return {
-      currentDomain: row.currentDomain,
-      lastAccess: row.lastAccess,
-      lastMemoryId: row.lastMemoryId
-    };
-  }
-
-  /**
-   * Save persistence state
-   * @param state Persistence state
-   */
-  async savePersistenceState(state: PersistenceState): Promise<void> {
-    const db = await this.getDatabase();
-    
-    // Check if persistence state exists
-    const exists = await db.get('SELECT 1 FROM PERSISTENCE WHERE id = 1');
-    
-    if (exists) {
-      // Update existing state
-      await db.run(
-        'UPDATE PERSISTENCE SET currentDomain = ?, lastAccess = ?, lastMemoryId = ? WHERE id = 1',
-        [state.currentDomain, state.lastAccess, state.lastMemoryId]
-      );
-    } else {
-      // Insert new state
-      await db.run(
-        'INSERT INTO PERSISTENCE (id, currentDomain, lastAccess, lastMemoryId) VALUES (1, ?, ?, ?)',
-        [state.currentDomain, state.lastAccess, state.lastMemoryId]
-      );
-    }
-  }
-
-  /**
-   * Get memories for a domain
-   * @param domain Domain ID
-   * @returns Object containing nodes and edges
-   */
-  async getMemories(domain: string): Promise<{ nodes: Map<string, MemoryNode>, edges: GraphEdge[] }> {
-    const db = await this.getDatabase();
-    
-    // Get nodes
-    const nodeRows = await db.all('SELECT * FROM MEMORY_NODES WHERE domain = ?', [domain]);
-    const nodes = new Map<string, MemoryNode>();
-    
-    for (const row of nodeRows) {
-      // Get tags for this node
-      const tagRows = await db.all('SELECT tag FROM MEMORY_TAGS WHERE nodeId = ?', [row.id]);
-      const tags = tagRows.map((t: { tag: string }) => t.tag);
-      
-      // Get domain refs for this node
-      const refRows = await db.all('SELECT * FROM DOMAIN_REFS WHERE nodeId = ?', [row.id]);
-      const domainRefs = refRows.map((ref: any) => ({
-        domain: ref.targetDomain,
-        nodeId: ref.targetNodeId,
-        description: ref.description,
-        bidirectional: ref.bidirectional === 1
-      }));
-      
-      nodes.set(row.id, {
-        id: row.id,
-        content: row.content,
-        timestamp: row.timestamp,
-        path: row.path,
-        tags: tags.length > 0 ? tags : undefined,
-        domainRefs: domainRefs.length > 0 ? domainRefs : undefined,
-        content_summary: row.content_summary,
-        summary_timestamp: row.summary_timestamp
-      });
-    }
-    
-    // Get edges
-    const edgeRows = await db.all('SELECT * FROM MEMORY_EDGES WHERE domain = ?', [domain]);
-    const edges = edgeRows.map((row: any) => ({
-      source: row.source,
-      target: row.target,
-      type: row.type,
-      strength: row.strength,
-      timestamp: row.timestamp
-    }));
-    
-    return { nodes, edges };
-  }
-
-  /**
-   * Save memories for a domain
-   * @param domain Domain ID
-   * @param nodes Map of node IDs to nodes
-   * @param edges Array of edges
-   */
-  async saveMemories(domain: string, nodes: Map<string, MemoryNode>, edges: GraphEdge[]): Promise<void> {
-    const db = await this.getDatabase();
-    
-    // Start a transaction
-    await db.run('BEGIN TRANSACTION');
-    
-    try {
-      // Clear existing data for this domain
-      await db.run('DELETE FROM MEMORY_NODES WHERE domain = ?', [domain]);
-      await db.run('DELETE FROM MEMORY_EDGES WHERE domain = ?', [domain]);
-      
-      // Insert nodes
-      for (const node of nodes.values()) {
-        await db.run(
-          'INSERT INTO MEMORY_NODES (id, domain, content, timestamp, path, content_summary, summary_timestamp) VALUES (?, ?, ?, ?, ?, ?, ?)',
-          [node.id, domain, node.content, node.timestamp, node.path || '/', node.content_summary, node.summary_timestamp]
-        );
-        
-        // Insert tags - use INSERT OR IGNORE to handle duplicate tags
-        if (node.tags && node.tags.length > 0) {
-          for (const tag of node.tags) {
-            await db.run(
-              'INSERT OR IGNORE INTO MEMORY_TAGS (nodeId, tag) VALUES (?, ?)',
-              [node.id, tag]
-            );
-          }
-        }
-        
-        // Insert domain refs - use INSERT OR IGNORE to handle duplicate domain references
-        if (node.domainRefs && node.domainRefs.length > 0) {
-          for (const ref of node.domainRefs) {
-            await db.run(
-              'INSERT OR IGNORE INTO DOMAIN_REFS (nodeId, domain, targetDomain, targetNodeId, description, bidirectional) VALUES (?, ?, ?, ?, ?, ?)',
-              [node.id, domain, ref.domain, ref.nodeId, ref.description || null, ref.bidirectional ? 1 : 0]
-            );
-          }
-        }
-      }
-      
-      // Insert edges - use INSERT OR REPLACE to handle duplicate edges while preserving updated values
-      for (const edge of edges) {
-        await db.run(
-          'INSERT OR REPLACE INTO MEMORY_EDGES (id, source, target, type, strength, timestamp, domain) VALUES (?, ?, ?, ?, ?, ?, ?)',
-          [edge.source + '-' + edge.target + '-' + edge.type, edge.source, edge.target, edge.type, edge.strength, edge.timestamp, domain]
-        );
-      }
-      
-      // Commit the transaction
-      await db.run('COMMIT');
-    } catch (error) {
-      // Rollback on error
-      await db.run('ROLLBACK');
-      throw error;
-    }
-  }
-
-  /**
    * Search memory content using full-text search
    * @param query Search query
    * @param domain Optional domain to restrict search to
@@ -401,7 +178,7 @@ export class SqliteMemoryStorage implements MemoryStorage {
    * @returns Array of matching memory nodes
    */
   async searchContent(query: string, domain?: string, maxResults: number = 20): Promise<MemoryNode[]> {
-    const db = await this.getDatabase();
+    const db = await this.getConnection();
     
     let sql = `
       SELECT m.* FROM MEMORY_NODES m
@@ -449,5 +226,75 @@ export class SqliteMemoryStorage implements MemoryStorage {
     }
     
     return results;
+  }
+
+  /**
+   * Execute a query that returns multiple rows
+   */
+  protected async executeQuery(connection: Database, sql: string, params: any[] = []): Promise<any[]> {
+    return connection.all(sql, params);
+  }
+
+  /**
+   * Execute a query that returns a single row
+   */
+  protected async executeQuerySingle(connection: Database, sql: string, params: any[] = []): Promise<any> {
+    return connection.get(sql, params);
+  }
+
+  /**
+   * Execute an update statement
+   */
+  protected async executeUpdate(connection: Database, sql: string, params: any[] = []): Promise<any> {
+    return connection.run(sql, params);
+  }
+
+  /**
+   * Begin a database transaction
+   */
+  protected async beginTransaction(connection: Database): Promise<void> {
+    await connection.run('BEGIN TRANSACTION');
+  }
+
+  /**
+   * Commit a database transaction
+   */
+  protected async commitTransaction(connection: Database): Promise<void> {
+    await connection.run('COMMIT');
+  }
+
+  /**
+   * Rollback a database transaction
+   */
+  protected async rollbackTransaction(connection: Database): Promise<void> {
+    await connection.run('ROLLBACK');
+  }
+
+  /**
+   * Get the appropriate INSERT IGNORE statement for SQLite
+   */
+  protected getInsertIgnoreStatement(table: string, valuesClause: string): string {
+    return `INSERT OR IGNORE INTO ${table} ${valuesClause}`;
+  }
+
+  /**
+   * Get the appropriate INSERT REPLACE statement for SQLite
+   */
+  protected getInsertReplaceStatement(table: string, valuesClause: string): string {
+    return `INSERT OR REPLACE INTO ${table} ${valuesClause}`;
+  }
+
+  /**
+   * Convert a SQLite boolean value (0/1) to a JavaScript boolean
+   */
+  protected getBooleanValue(value: any): boolean {
+    return value === 1;
+  }
+
+  /**
+   * Convert a JavaScript boolean to a SQLite value (0/1)
+   */
+  protected setBooleanValue(value?: boolean): number {
+    return value ? 1 : 0;
   }
 }

--- a/src/storage/StorageFactory.ts
+++ b/src/storage/StorageFactory.ts
@@ -1,6 +1,8 @@
 import { MemoryStorage, StorageType } from './MemoryStorage.js';
 import { JsonMemoryStorage } from './JsonMemoryStorage.js';
 import { SqliteMemoryStorage } from './SqliteMemoryStorage.js';
+import { MariaDbMemoryStorage } from './MariaDbMemoryStorage.js';
+import type { PoolOptions } from 'mysql2/promise';
 
 /**
  * Factory for creating storage implementations
@@ -10,14 +12,17 @@ export class StorageFactory {
    * Create a storage implementation based on the specified type
    * @param type Storage type
    * @param storageDir Storage directory
+   * @param dbConfig Optional database configuration for MariaDB
    * @returns Storage implementation
    */
-  static createStorage(type: StorageType, storageDir: string): MemoryStorage {
+  static createStorage(type: StorageType, storageDir: string, dbConfig?: PoolOptions): MemoryStorage {
     switch (type) {
       case StorageType.JSON:
         return new JsonMemoryStorage(storageDir);
       case StorageType.SQLITE:
         return new SqliteMemoryStorage(storageDir);
+      case StorageType.MARIADB:
+        return new MariaDbMemoryStorage(storageDir, dbConfig);
       default:
         throw new Error(`Unknown storage type: ${type}`);
     }

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -51,7 +51,8 @@ export interface MemoryGraphConfig {
   storageDir: string;
   defaultPath?: string;
   defaultDomain?: string;
-  storageType?: string; // 'json' or 'sqlite'
+  storageType?: string; // 'json', 'sqlite', or 'mariadb'
+  dbConfig?: any; // Database configuration for MariaDB
 }
 
 export interface Relationship {


### PR DESCRIPTION
## Summary
- Adds MariaDB as a third storage backend option alongside JSON and SQLite
- Implements an abstract DatabaseStorage class to share common SQL functionality
- Provides environment variable configuration for MariaDB connection parameters
- Updates documentation with MariaDB setup and configuration instructions

## Technical Details
- Creates a database abstraction layer with shared functionality for SQL-based backends
- Implements connection pooling for efficient database access
- Adds full-text search capabilities for MariaDB
- Updates the MemoryGraph constructor to accept database configuration options
- Adds MariaDB to the StorageType enum

## Test plan
- Verify JSON and SQLite storage still function correctly
- Test MariaDB storage with a local MariaDB server
- Ensure all memory operations work correctly with the new storage backend
- Validate full-text search functionality in MariaDB

This enhancement provides a more scalable storage option for larger deployments or environments where a central database server is preferred.